### PR TITLE
[PTTF-32] 글자 크기별 기본 css tailwindClass 형식으로 사전 작성

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,7 +21,8 @@
   font-weight: 400;
   font-style: normal;
   src: url("https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Regular.eot");
-  src: url("https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Regular.eot?#iefix")
+  src:
+    url("https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Regular.eot?#iefix")
       format("embedded-opentype"),
     url("https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Regular.woff2")
       format("woff2"),
@@ -35,7 +36,8 @@
 @font-face {
   font-family: "Spoqa Han Sans Neo";
   font-weight: 700;
-  src: local("Spoqa Han Sans Neo Bold"),
+  src:
+    local("Spoqa Han Sans Neo Bold"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.woff2")
       format("woff2"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.woff")
@@ -47,7 +49,8 @@
 @font-face {
   font-family: "Spoqa Han Sans Neo";
   font-weight: 500;
-  src: local("Spoqa Han Sans Neo Medium"),
+  src:
+    local("Spoqa Han Sans Neo Medium"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.woff2")
       format("woff2"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.woff")
@@ -59,7 +62,8 @@
 @font-face {
   font-family: "Spoqa Han Sans Neo";
   font-weight: 400;
-  src: local("Spoqa Han Sans Neo Regular"),
+  src:
+    local("Spoqa Han Sans Neo Regular"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff2")
       format("woff2"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff")
@@ -71,7 +75,8 @@
 @font-face {
   font-family: "Spoqa Han Sans Neo";
   font-weight: 300;
-  src: local("Spoqa Han Sans Neo Light"),
+  src:
+    local("Spoqa Han Sans Neo Light"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.woff2")
       format("woff2"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Light.woff")
@@ -83,7 +88,8 @@
 @font-face {
   font-family: "Spoqa Han Sans Neo";
   font-weight: 100;
-  src: local("Spoqa Han Sans Neo Thin"),
+  src:
+    local("Spoqa Han Sans Neo Thin"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.woff2")
       format("woff2"),
     url("https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Thin.woff")
@@ -94,6 +100,48 @@
 
 body {
   font-family: "Spoqa Han Sans Neo", sans-serif;
+}
+
+@layer components {
+  .h1 {
+    @apply text-[1.75rem] font-bold leading-normal tracking-[0.035rem];
+  }
+
+  .h2 {
+    @apply text-2xl font-bold leading-normal tracking-[0.03rem];
+  }
+
+  .h3 {
+    @apply text-xl font-bold leading-normal;
+  }
+
+  .h4 {
+    @apply text-lg leading-normal;
+  }
+
+  .h4-bold {
+    @apply text-lg font-bold leading-normal;
+  }
+
+  .body1 {
+    @apply text-base leading-[1.625rem];
+  }
+
+  .body1-bold {
+    @apply text-base font-bold leading-[1.25rem];
+  }
+
+  .body2 {
+    @apply text-sm leading-[1.57rem];
+  }
+
+  .body2-bold {
+    @apply text-sm font-bold leading-normal;
+  }
+
+  .caption {
+    @apply text-xs leading-[1.33rem];
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## 🚀 작업 내용

- body1-regular, body2-regular, h1, h2 등 각 상황에 따른 폰트별 크기를 tailwind식으로 사전 작성하였습니다.

## 📝 참고 사항
속성 목록은 다음과 같습니다. (원본과 이름이 다를 경우 추가 작성)
- body1  (body1-regular)
- body1-bold
- body2  (body2-regular)
- body2-bold
- caption
- h1
- h2
- h3
- h4
- h4-bold

그냥 간단하게 regular만 빼고 그대로 치시면 될 것 같습니다.

## 🖼️ 스크린샷

### global CSS 변경 사항입니다.
![image](https://github.com/royxk/codeit_team5_project/assets/155033024/0f125826-a27e-4ca0-9747-b0f315ced680)

### 간단한 사용법입니다.
<img width="411" alt="스크린샷 2024-04-17 오후 3 09 35" src="https://github.com/royxk/codeit_team5_project/assets/155033024/318467b5-1029-4c96-a114-5155692546db">
<img width="393" alt="스크린샷 2024-04-17 오후 3 09 39" src="https://github.com/royxk/codeit_team5_project/assets/155033024/4cca8737-0d3d-43e0-82cd-3d847ca779ba">

### HTML태그에 종속되지 않으므로, class에 반드시 추가로 작성해주셔야 합니다.
<img width="353" alt="스크린샷 2024-04-17 오후 3 09 48" src="https://github.com/royxk/codeit_team5_project/assets/155033024/5e742c38-f85f-4560-b600-3ab10e41b5b9">
<img width="333" alt="스크린샷 2024-04-17 오후 3 09 51" src="https://github.com/royxk/codeit_team5_project/assets/155033024/97f4815a-ef7e-4b69-8a94-513dfe656fbf">

## 🚨 관련 이슈

- 기존 작성 코드와의 호환성을 고려하여 기존 HTML태그에 일괄 적용 하는것이 아니라 class를 통해 적용하도록 한 것이므로, 이점 참고해 주시기 바랍니다.
