### PR TITLE
[PTTF-37] footer layout 수정

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -34,8 +34,11 @@ const Footer = () => {
           ©codeit - 2023
         </a>
 
-        <div className="flex gap-[10px]">
-          <Link href={""} className="body1 text-gray-50 mob:w-min">
+        <div className="flex">
+          <Link
+            href={""}
+            className="body1 whitespace-nowrap pr-[30px] text-gray-50"
+          >
             Privacy Policy
           </Link>
           <Link href={""} className="body1 text-gray-50">


### PR DESCRIPTION
## 🚀 작업 내용

- footer layout에서 mob 사이즈(768px 이하) 일 때의 디자인 수정

## 📝 참고 사항

- Privacy Policy 부분이 768px 이하일때 두 줄이 되어 해당 부분을 수정했습니다.
- 간격 Privacy Policy와 FAQ의 간격을 Figma 디자인에 맞게 10px -> 30px로 조정했습니다.

## 🖼️ 스크린샷



## 🚨 관련 이슈

- 없습니다.
