### PR TITLE
[PTTF-41] Pagination, StatusLabel, Table 컴포넌트 연결

### DIFF
--- a/src/components/common/ApproveButtons.tsx
+++ b/src/components/common/ApproveButtons.tsx
@@ -7,14 +7,14 @@ const ApproveButtons = () => {
   return (
     <div className='flex gap-3'>
       <button
-        className='flex items-center bg-white text-primary border border-primary rounded-md px-5 h-[38px] py-[10px] font-bold text-sm hover:bg-red-10'
+        className='flex items-center bg-white text-primary border border-primary rounded-md px-5 h-[38px] py-[10px] font-bold text-sm hover:bg-red-10 mob:font-normal'
         type='button'
         onClick={handleClick}
       >
         거절하기
       </button>
       <button
-        className='flex items-center bg-white text-blue-20 border border-blue-20 rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-blue-10'
+        className='flex items-center bg-white text-blue-20 border border-blue-20 rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-blue-10 mob:font-normal'
         type='button'
         onClick={handleClick}
       >

--- a/src/components/common/EmployeeTable.tsx
+++ b/src/components/common/EmployeeTable.tsx
@@ -1,12 +1,24 @@
 import { SHOP_APPLY_API_RESPONSE_DATA } from "@/util/constants/table_mock_data";
 import { EmployeeTableData, convertEmployeeTableData } from "@/util/convertData";
 import Table from "./Table";
+import Button from "./Button";
+import Link from "next/link";
 
 const EMPLOYEE_TABLE_HEADER = ['가게', '일자', '시급', '상태'];
 
 const EmployeeTable = () => {
   const employeeData: EmployeeTableData[] = convertEmployeeTableData(SHOP_APPLY_API_RESPONSE_DATA);
-  return <Table<EmployeeTableData> headerData={EMPLOYEE_TABLE_HEADER} applyData={employeeData} />
+
+  return (
+    employeeData.length ? <Table<EmployeeTableData> headerData={EMPLOYEE_TABLE_HEADER} applyData={employeeData} />
+    :
+    <div className="flex flex-col items-center gap-6 w-full max-w-[964px] border border-gray-20 rounded-lg px-6 py-[60px] mob:text-sm">
+      <p className="text-black">아직 신청 내역이 없어요.</p>
+      <Link href="/">
+        <Button size="large" color="red">공고 보러가기</Button>
+      </Link>
+    </div>
+  );
 }
 
 export default EmployeeTable;

--- a/src/components/common/EmployerTable.tsx
+++ b/src/components/common/EmployerTable.tsx
@@ -6,7 +6,14 @@ const EMPLOYER_TABLE_HEADER = ['신청자', '소개', '전화번호', '상태'];
 
 const EmployerTable = () => {
   const employerData: EmployerTableData[] = convertEmployerTableData(USER_API_RESPONSE);
-  return <Table<EmployerTableData> headerData={EMPLOYER_TABLE_HEADER} applyData={employerData} />
+  
+  return (
+    employerData.length ? <Table<EmployerTableData> headerData={EMPLOYER_TABLE_HEADER} applyData={employerData} />
+    :
+    <div className="flex flex-col justify-center items-center w-full max-w-[964px] h-[400px] border border-gray-20 rounded-lg mob:text-sm">
+      <p className="text-gray-50 text-xl">아직 지원자가 없어요.</p>
+    </div>
+  );
 }
 
 export default EmployerTable;

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 
 interface PaginationProps {
   rawPageData: unknown[];
-  setCurrentPageData: (currentPageData: unknown[]) => void;
+  setCurrentPageData: (currentPageData: number) => void;
   pageItemLimit?: number;
 }
 
@@ -86,7 +86,7 @@ const Pagination = ({
   const handlePageNumberChange = (index: number) => {
     handlePageList(index);
     setCurrentPage(index);
-    setCurrentPageData(pageData[index]);
+    setCurrentPageData(index);
   };
 
   // 페이지 숫자 양 옆의 화살표 버튼 클릭 시 실행할 함수

--- a/src/components/common/StatusLabel.tsx
+++ b/src/components/common/StatusLabel.tsx
@@ -2,7 +2,7 @@ interface StatusLabelProp {
   status: Status;
 }
 
-export type Status = "pending" | "accepted" | "rejected" | "canceled";
+type Status = "pending" | "accepted" | "rejected" | "canceled";
 
 function StatusCssString(status: Status) {
   let statusCss;

--- a/src/components/common/StatusLabel.tsx
+++ b/src/components/common/StatusLabel.tsx
@@ -2,7 +2,7 @@ interface StatusLabelProp {
   status: Status;
 }
 
-type Status = "pending" | "accepted" | "rejected" | "canceled";
+export type Status = "pending" | "accepted" | "rejected" | "canceled";
 
 function StatusCssString(status: Status) {
   let statusCss;

--- a/src/components/common/StatusLabel.tsx
+++ b/src/components/common/StatusLabel.tsx
@@ -45,7 +45,7 @@ const StatusLabel = ({ status }: StatusLabelProp) => {
   const statusCss = StatusCssString(status);
   const labelName = LabelString(status);
   return (
-    <div className={`${statusCss} border-none rounded-[20px] text-center px-[10px] py-[6px] font-bold text-sm`}>
+    <div className={`${statusCss} border-none rounded-[20px] text-center px-[10px] py-[6px] font-bold text-sm mob:font-normal`}>
       {labelName}
     </div>
   );

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -1,4 +1,7 @@
+'use client';
+import { useState } from "react";
 import ApproveButtons from "./ApproveButtons";
+import Pagination from "./Pagination";
 import StatusLabel, { Status } from "./StatusLabel";
 import TableHeader from "./TableHeader";
 
@@ -6,6 +9,7 @@ interface TableProps<T> {
   headerData: string[];
   applyData: T[];
 }
+
 
 interface ApplyData {
   apply_id: string,
@@ -26,6 +30,15 @@ interface ApplyData {
 
 const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) => {
   const isEmployee = headerData.includes("가게");
+  const [pageData, setPageData] = useState([]);
+  const currentPageData: any[] = [];
+  
+  for (let i = 0; i < applyData.length; i += 5) {
+    currentPageData.push(applyData.slice(i, i + 5));
+  }
+  const handleData = (pageData: number) => {
+    setPageData(currentPageData[pageData]);
+  }
 
   return (
     <div className='relative w-full max-w-[964px] border border-gray-20 rounded-lg overflow-hidden mob:text-sm'>
@@ -33,7 +46,7 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
         <table className='table-auto'>
           <TableHeader headerData={headerData}/>
           <tbody>
-            {applyData.map((data) => {
+            {pageData.map((data) => {
               const {
                 apply_id,
                 status,
@@ -66,7 +79,9 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
           </tbody>
         </table>
       </div>
-      <div className='flex justify-center p-6'>페이지네이션 컴포넌트</div>
+      <div className='flex justify-center p-6'>
+        <Pagination rawPageData={applyData} setCurrentPageData={handleData}/>
+      </div>
     </div>
   );
 };

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -1,3 +1,5 @@
+import ApproveButtons from "./ApproveButtons";
+import StatusLabel, { Status } from "./StatusLabel";
 import TableHeader from "./TableHeader";
 
 interface TableProps<T> {
@@ -7,7 +9,7 @@ interface TableProps<T> {
 
 interface ApplyData {
   apply_id: string,
-  status: string,
+  status: Status,
   shopName?: string,
   hourlyPay?: number,
   startsAt?: string,
@@ -43,10 +45,6 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
                 phoneNumber,
                 bio
               } = data;
-              const statusLabel = status === "pending" ? "대기중"
-                : status === "accepted" ? "승인 완료"
-                : status === "rejected" ? "거절"
-                : "취소";
               return (
                 <tr key={apply_id} className='border-b border-gray-20'>
                   <td className='bg-white px-3 py-5 w-full min-w-[226px] sticky z-10 left-0'>
@@ -55,11 +53,12 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
                   <td className='bg-white px-3 py-5 w-full min-w-[300px]'>
                     {isEmployee ? `${startsAt}(${workHour}시간)` : bio}
                   </td>
-                  <td className='bg-white px-3 py-5 w-full min-w-[226px]'>
+                  <td className='bg-white px-3 py-5 w-full min-w-[200px]'>
                     {isEmployee ? `${hourlyPay}원` : phoneNumber}
                   </td>
-                  <td className='bg-white px-3 py-5 w-full min-w-[226px]'>
-                    {statusLabel}
+                  <td className='bg-white px-3 py-5 w-full min-w-[236px]'>
+                    {!isEmployee && status === "pending" ? <ApproveButtons />
+                      : <StatusLabel status={status}/>}
                   </td>
                 </tr>
               )

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import ApproveButtons from "./ApproveButtons";
 import Pagination from "./Pagination";
-import StatusLabel, { Status } from "./StatusLabel";
+import StatusLabel from "./StatusLabel";
 import TableHeader from "./TableHeader";
 
 interface TableProps<T> {
@@ -13,7 +13,7 @@ interface TableProps<T> {
 
 interface ApplyData {
   apply_id: string,
-  status: Status,
+  status: string,
   shopName?: string,
   hourlyPay?: number,
   startsAt?: string,

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -36,6 +36,7 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
   for (let i = 0; i < applyData.length; i += 5) {
     currentPageData.push(applyData.slice(i, i + 5));
   }
+
   const handleData = (pageData: number) => {
     setPageData(currentPageData[pageData]);
   }
@@ -59,12 +60,14 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
                 bio
               } = data;
               return (
-                <tr key={apply_id} className='border-b border-gray-20'>
+                <tr key={apply_id} className='border-b border-gray-20 max-h-[51px]'>
                   <td className='bg-white px-3 py-5 w-full min-w-[226px] sticky z-10 left-0'>
                     {isEmployee ? shopName : userName}
                   </td>
-                  <td className='bg-white px-3 py-5 w-full min-w-[300px]'>
-                    {isEmployee ? `${startsAt}(${workHour}시간)` : bio}
+                  <td className='bg-white px-3 py-5 w-full min-w-[300px] align-middle'>
+                    <div className='line-clamp-2'>
+                      {isEmployee ? `${startsAt}(${workHour}시간)` : bio}
+                    </div>
                   </td>
                   <td className='bg-white px-3 py-5 w-full min-w-[200px]'>
                     {isEmployee ? `${hourlyPay}원` : phoneNumber}

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -82,9 +82,7 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
           </tbody>
         </table>
       </div>
-      <div className='flex justify-center p-6'>
-        <Pagination rawPageData={applyData} setCurrentPageData={handleData}/>
-      </div>
+      <Pagination rawPageData={applyData} setCurrentPageData={handleData}/>
     </div>
   );
 };

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -28,7 +28,7 @@ const Table = <T extends ApplyData>({ headerData, applyData }: TableProps<T>) =>
   const isEmployee = headerData.includes("가게");
 
   return (
-    <div className='relative w-full max-w-[964px] border border-gray-20 rounded-lg overflow-hidden'>
+    <div className='relative w-full max-w-[964px] border border-gray-20 rounded-lg overflow-hidden mob:text-sm'>
       <div className='overflow-x-auto' style={{ scrollbarWidth: 'none' }}>
         <table className='table-auto'>
           <TableHeader headerData={headerData}/>

--- a/src/util/constants/table_mock_data.ts
+++ b/src/util/constants/table_mock_data.ts
@@ -218,7 +218,7 @@ export const USER_API_RESPONSE = {
     {
       "item": {
         "id": "string",
-        "status": "pending",
+        "status": "accepted",
         "createdAt": "string",
         "user": {
           "item": {
@@ -236,7 +236,7 @@ export const USER_API_RESPONSE = {
     {
       "item": {
         "id": "string",
-        "status": "pending",
+        "status": "accepted",
         "createdAt": "string",
         "user": {
           "item": {
@@ -272,7 +272,7 @@ export const USER_API_RESPONSE = {
     {
       "item": {
         "id": "string",
-        "status": "pending",
+        "status": "rejected",
         "createdAt": "string",
         "user": {
           "item": {
@@ -290,7 +290,7 @@ export const USER_API_RESPONSE = {
     {
       "item": {
         "id": "string",
-        "status": "pending",
+        "status": "canceled",
         "createdAt": "string",
         "user": {
           "item": {

--- a/src/util/constants/table_mock_data.ts
+++ b/src/util/constants/table_mock_data.ts
@@ -215,5 +215,203 @@ export const USER_API_RESPONSE = {
         },
       },
     },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저6",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "양서연",
+            "phone": "010-7777-4444",
+            "address": "string",
+            "bio": "감사합니다.",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저7",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "김세동",
+            "phone": "010-4444-7777",
+            "address": "string",
+            "bio": "최선을 다해서 일하겠습니다!",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저8",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "고기",
+            "phone": "010-8888-8888",
+            "address": "string",
+            "bio": "",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저9",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "이름",
+            "phone": "010-9999-9999",
+            "address": "string",
+            "bio": "하하하하하핳하",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저10",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "고기먹고싶다",
+            "phone": "010-6666-8888",
+            "address": "string",
+            "bio": "ㅇㅁㄹㄴㅁㄹㅇㄴㅁ",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저11",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "고기탐",
+            "phone": "010-8888-6666",
+            "address": "string",
+            "bio": "룰루",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저12",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "생선회",
+            "phone": "010-7777-8888",
+            "address": "string",
+            "bio": "유후",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저13",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "연어 최고",
+            "phone": "010-8888-7777",
+            "address": "string",
+            "bio": "언제까지 해야되는 거냐",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저14",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "그만해액",
+            "phone": "010-9999-8888",
+            "address": "string",
+            "bio": "야아아아아아아악",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저15",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "테스트",
+            "phone": "010-0000-8888",
+            "address": "string",
+            "bio": "아아 마이크 테스트 원투원투",
+          },
+        },
+      },
+    },
+    {
+      "item": {
+        "id": "string",
+        "status": "pending",
+        "createdAt": "string",
+        "user": {
+          "item": {
+            "id": "유저16",
+            "email": "string",
+            "type": "employer | employee",
+            "name": "마지막",
+            "phone": "010-1111-8888",
+            "address": "string",
+            "bio": "끝!",
+          },
+        },
+      },
+    },
   ],
 }

--- a/src/util/constants/table_mock_data.ts
+++ b/src/util/constants/table_mock_data.ts
@@ -123,7 +123,154 @@ export const SHOP_APPLY_API_RESPONSE_DATA = {
   ]
 }
 
-export const USER_API_RESPONSE = {
+export const USER_API_RESPONSE =
+// {
+//   "offset": 0,
+//   "limit": 10,
+//   "count": 2,
+//   "hasNext": false,
+//   "items": [
+//     {
+//       "item": {
+//         "id": "48874724-ecc7-4e57-bdb8-d5aa8dcc9028",
+//         "status": "accepted",
+//         "createdAt": "2024-04-15T07:21:57.898Z",
+//         "user": {
+//           "item": {
+//             "id": "52dac023-f435-4655-9b3c-8751afc65a71",
+//             "email": "white@naver.com",
+//             "type": "employer"
+//           },
+//           "href": "/api/0-1/the-julge/users/52dac023-f435-4655-9b3c-8751afc65a71"
+//         },
+//         "shop": {
+//           "item": {
+//             "id": "52200d57-25a3-4910-9903-e524d1d67a57",
+//             "name": "음머어 소갈비",
+//             "category": "한식",
+//             "address1": "서울시 종로구",
+//             "address2": "소갈비길",
+//             "description": "싸고 맛있는집",
+//             "imageUrl": "https://bootcamp-project-api.s3.ap-northeast-2.amazonaws.com/0-1/the-julge/ce383d5a-c9f3-43ff-84ce-4844dcbeb1e2-aj-McsNra2VRQQ-unsplash.jpg",
+//             "originalHourlyPay": 50000
+//           },
+//           "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57"
+//         },
+//         "notice": {
+//           "item": {
+//             "id": "ba1e7554-0b2b-4583-9a6f-a16dae71b46a",
+//             "hourlyPay": 500000,
+//             "description": "string",
+//             "startsAt": "2024-05-01T00:00:00.000Z",
+//             "workhour": 5,
+//             "closed": true
+//           },
+//           "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a"
+//         }
+//       },
+//       "links": [
+//         {
+//           "rel": "update",
+//           "description": "지원 승인/거절",
+//           "method": "PUT",
+//           "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a/applications/48874724-ecc7-4e57-bdb8-d5aa8dcc9028",
+//           "body": {
+//             "status": "accepted | rejected"
+//           }
+//         }
+//       ]
+//     },
+//     {
+//       "item": {
+//         "id": "a0ef59df-f27b-4659-a2ac-7c668374df69",
+//         "status": "pending",
+//         "createdAt": "2024-04-15T07:18:02.283Z",
+//         "user": {
+//           "item": {
+//             "id": "52dac023-f435-4655-9b3c-8751afc65a71",
+//             "email": "white@naver.com",
+//             "type": "employer"
+//           },
+//           "href": "/api/0-1/the-julge/users/52dac023-f435-4655-9b3c-8751afc65a71"
+//         },
+//         "shop": {
+//           "item": {
+//             "id": "52200d57-25a3-4910-9903-e524d1d67a57",
+//             "name": "음머어 소갈비",
+//             "category": "한식",
+//             "address1": "서울시 종로구",
+//             "address2": "소갈비길",
+//             "description": "싸고 맛있는집",
+//             "imageUrl": "https://bootcamp-project-api.s3.ap-northeast-2.amazonaws.com/0-1/the-julge/ce383d5a-c9f3-43ff-84ce-4844dcbeb1e2-aj-McsNra2VRQQ-unsplash.jpg",
+//             "originalHourlyPay": 50000
+//           },
+//           "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57"
+//         },
+//         "notice": {
+//           "item": {
+//             "id": "ba1e7554-0b2b-4583-9a6f-a16dae71b46a",
+//             "hourlyPay": 500000,
+//             "description": "string",
+//             "startsAt": "2024-05-01T00:00:00.000Z",
+//             "workhour": 5,
+//             "closed": true
+//           },
+//           "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a"
+//         }
+//       },
+//       "links": [
+//         {
+//           "rel": "update",
+//           "description": "지원 승인/거절",
+//           "method": "PUT",
+//           "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a/applications/a0ef59df-f27b-4659-a2ac-7c668374df69",
+//           "body": {
+//             "status": "accepted | rejected"
+//           }
+//         }
+//       ]
+//     }
+//   ],
+//   "links": [
+//     {
+//       "rel": "self",
+//       "description": "현재 페이지",
+//       "method": "GET",
+//       "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a/applications?offset=0&limit=10"
+//     },
+//     {
+//       "rel": "prev",
+//       "description": "이전 페이지",
+//       "method": "GET",
+//       "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a/applications?offset=0&limit=10"
+//     },
+//     {
+//       "rel": "next",
+//       "description": "다음 페이지",
+//       "method": "GET",
+//       "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a/applications?offset=10&limit=10"
+//     },
+//     {
+//       "rel": "create",
+//       "description": "지원하기",
+//       "method": "POST",
+//       "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a/applications"
+//     },
+//     {
+//       "rel": "shop",
+//       "description": "가게 정보",
+//       "method": "GET",
+//       "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57"
+//     },
+//     {
+//       "rel": "notice",
+//       "description": "공고 정보",
+//       "method": "GET",
+//       "href": "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a"
+//     }
+//   ]
+// }
+{
   "items": [
     {
       "item": {

--- a/src/util/convertData.ts
+++ b/src/util/convertData.ts
@@ -1,14 +1,11 @@
 // 응답 데이터 필요한 타입 정의
-
-import { Status } from "@/components/common/StatusLabel";
-
 // 알바님(일반회원) 공고 지원 목록 데이터 타입
 type ApplyListApiResponse = {
   items:
     {
       item: {
         id: string;
-        status: Status;
+        status: string;
         shop: {
           item: {
             name: string;
@@ -31,7 +28,7 @@ type ApplicantListApiResponse = {
   items:
     {
       item: {
-        status: Status;
+        status: string;
         user: {
           item: {
             id: string;
@@ -47,7 +44,7 @@ type ApplicantListApiResponse = {
 // 새로운 데이터 타입 정의
 interface CommonData {
   apply_id: string;
-  status: Status;
+  status: string;
 }
 
 export interface EmployeeTableData extends CommonData {

--- a/src/util/convertData.ts
+++ b/src/util/convertData.ts
@@ -1,11 +1,14 @@
 // 응답 데이터 필요한 타입 정의
+
+import { Status } from "@/components/common/StatusLabel";
+
 // 알바님(일반회원) 공고 지원 목록 데이터 타입
 type ApplyListApiResponse = {
   items:
     {
       item: {
         id: string;
-        status: string;
+        status: Status;
         shop: {
           item: {
             name: string;
@@ -28,7 +31,7 @@ type ApplicantListApiResponse = {
   items:
     {
       item: {
-        status: string;
+        status: Status;
         user: {
           item: {
             id: string;
@@ -44,7 +47,7 @@ type ApplicantListApiResponse = {
 // 새로운 데이터 타입 정의
 interface CommonData {
   apply_id: string;
-  status: string;
+  status: Status;
 }
 
 export interface EmployeeTableData extends CommonData {

--- a/src/util/convertData.ts
+++ b/src/util/convertData.ts
@@ -4,6 +4,7 @@ type ApplyListApiResponse = {
   items:
     {
       item: {
+        id: string;
         status: string;
         shop: {
           item: {
@@ -62,9 +63,9 @@ export interface EmployerTableData extends CommonData {
 //Table 컴포넌트에서 사용할 수 있도록 데이터를 변환하는 함수.
 export const convertEmployeeTableData = (responseData: ApplyListApiResponse): EmployeeTableData[] => {
   return responseData.items.map((data) => {
-    const { shop, notice, status } = data.item;
+    const { id, shop, notice, status } = data.item;
     return {
-      "apply_id": notice.item.id,
+      "apply_id": id,
       "shopName": shop.item.name,
       "hourlyPay": notice.item.hourlyPay,
       "startsAt": notice.item.startsAt,


### PR DESCRIPTION
## 🚀 작업 내용

- StatusLabel 컴포넌트를 Table 컴포넌트에 연결해 해당 내용의 상태에 따라 알맞은 라벨이 보이도록 했습니다.
- Pagination 컴포넌트에 넘겨줄 applyData 가공, set함수 작성 후 prop으로 내려주었습니다.
- 각 테이블에서 데이터가 없는 경우 보여질 UI를 구현했습니다.

## 📝 참고 사항

- Pagination의 prop중 setCurrentPageData 함수가 받는 argument를 unknown에서 number 값으로 변경했습니다.
- status 데이터의 타입을 string으로 변경

## 🖼️ 스크린샷

- StatusLabel, Pagination 적용 후 실제 시연된 모습
![스크린샷 2024-04-19 153945](https://github.com/royxk/codeit_team5_project/assets/155137866/05000b4c-49b8-442d-8f7b-ea857e768831)

- [일반 회원] 지원 목록이 없을 때
![스크린샷 2024-04-19 161850](https://github.com/royxk/codeit_team5_project/assets/155137866/93d15e43-d872-4cfb-bdbc-9398813cfc38)

- [사장님] 지원자 목록이 없을 때
![스크린샷 2024-04-19 161921](https://github.com/royxk/codeit_team5_project/assets/155137866/254521c8-01bd-4bc4-aa59-979f85374f64)

## 🚨 관련 이슈

- status 데이터의 타입을 "pending" | "accepted" | "rejected" | "canceled"으로 지정해 두었는데 타입 에러가 발생, string으로 전부 바꾸어 해결했습니다.
- Pagination이 받는 prop중 set함수의 argument였던 pageData[index]가 부적절하다고 판단, 세동님께 설명을 드리고 argument를  pageData[index]가 아닌 index로 변경. 페이지 버튼을 클릭하면 해당 index 넘버를 받아와서 그 페이지에 해당하는 데이터(5개)만 보여질 수 있도록 구현했습니다.
