### PR TITLE
[PTTF-66] 사장이 등록한 공고 무한 스크롤 컴포넌트 및 사장페이지 일부 버그 수정

### DIFF
--- a/src/app/employer/page.tsx
+++ b/src/app/employer/page.tsx
@@ -58,7 +58,9 @@ const Employer = async () => {
       </div>
       {shopData && (
         <div className="mx-auto flex w-full justify-center bg-gray-5 px-8 py-[3.75rem]">
-          <PostEmployer shopData={shopData} noticeList={noticeList} />
+          <div className="w-full max-w-[64.25rem]">
+            <PostEmployer shopData={shopData} fetchedNoticeList={noticeList} />
+          </div>
         </div>
       )}
     </div>

--- a/src/app/employer/page.tsx
+++ b/src/app/employer/page.tsx
@@ -14,25 +14,26 @@ const getServerSideProps = async () => {
 
   if (uid !== undefined) {
     const { item } = await mydataApiResponse(uid);
-    const sid = getServerSideCookie("sid");
+    const sid = getServerSideCookie("sid") || item.shop.item.id;
 
     if (item.type === "employee") {
-      return { uid, item };
-    }
-
-    if (!sid === undefined && item.type === "employer" && item.shop) {
-      const { id: shopId } = item.shop.item;
-      const shopData = await searchShopInformationApiResponse(shopId);
-      const noticeList = await searchShopNoticeApiResponse(shopId, {
-        limit: 6,
-      });
-      return { uid, shopData, noticeList };
+      const type = "employee";
+      return { uid, type };
     }
 
     if (sid) {
       const shopData = await searchShopInformationApiResponse(sid);
-      const noticeList = await searchShopNoticeApiResponse(sid);
-      return { uid, shopData, noticeList };
+      const noticeList = await searchShopNoticeApiResponse(sid, {
+        limit: 6,
+      });
+      const type = "employer";
+      return { uid, type, shopData, noticeList };
+    }
+
+    if (!sid) {
+      const shopData = null;
+      const type = "employer";
+      return { uid, type, shopData };
     }
   }
 
@@ -40,12 +41,13 @@ const getServerSideProps = async () => {
 };
 
 const Employer = async () => {
-  const { uid, item, shopData, noticeList } = await getServerSideProps();
+  const { uid, type, shopData, noticeList } = await getServerSideProps();
+
   if (uid === undefined) {
     redirect("/signin");
   }
 
-  if (item.type === "employee") {
+  if (type === "employee") {
     redirect("/");
   }
 

--- a/src/app/employer/page.tsx
+++ b/src/app/employer/page.tsx
@@ -44,7 +44,7 @@ const Employer = async () => {
   return (
     <div className="mx-auto min-h-[calc(100vh-10.625rem)] max-w-[64.25rem] px-8 py-[3.75rem]">
       <StoreDetail data={shopData} />
-      <PostEmployer shopData={shopData} noticeList={noticeList} />
+      {shopData && <PostEmployer shopData={shopData} noticeList={noticeList} />}
     </div>
   );
 };

--- a/src/app/employer/page.tsx
+++ b/src/app/employer/page.tsx
@@ -3,9 +3,11 @@ import StoreDetail from "@/components/common/StoreDetail";
 import {
   mydataApiResponse,
   searchShopInformationApiResponse,
+  searchShopNoticeApiResponse,
 } from "@/util/api";
 import { redirect } from "next/navigation";
 import { getServerSideCookie } from "../utils/serverCookies";
+import PostEmployer from "@/components/employer/PostEmployer";
 
 const getServerSideProps = async () => {
   const uid = getServerSideCookie("uid");
@@ -17,12 +19,16 @@ const getServerSideProps = async () => {
     if (!sid === undefined && item.type === "employer" && item.shop) {
       const { id: shopId } = item.shop.item;
       const shopData = await searchShopInformationApiResponse(shopId);
-      return { uid, shopData };
+      const noticeList = await searchShopNoticeApiResponse(shopId, {
+        limit: 6,
+      });
+      return { uid, shopData, noticeList };
     }
 
     if (sid) {
       const shopData = await searchShopInformationApiResponse(sid);
-      return { uid, shopData };
+      const noticeList = await searchShopNoticeApiResponse(sid);
+      return { uid, shopData, noticeList };
     }
   }
 
@@ -30,7 +36,7 @@ const getServerSideProps = async () => {
 };
 
 const Employer = async () => {
-  const { uid, shopData } = await getServerSideProps();
+  const { uid, shopData, noticeList } = await getServerSideProps();
   if (uid === undefined) {
     redirect("/signin");
   }
@@ -38,6 +44,7 @@ const Employer = async () => {
   return (
     <div className="mx-auto min-h-[calc(100vh-10.625rem)] max-w-[64.25rem] px-8 py-[3.75rem]">
       <StoreDetail data={shopData} />
+      <PostEmployer shopData={shopData} noticeList={noticeList} />
     </div>
   );
 };

--- a/src/app/employer/page.tsx
+++ b/src/app/employer/page.tsx
@@ -16,6 +16,10 @@ const getServerSideProps = async () => {
     const { item } = await mydataApiResponse(uid);
     const sid = getServerSideCookie("sid");
 
+    if (item.type === "employee") {
+      return { uid, item };
+    }
+
     if (!sid === undefined && item.type === "employer" && item.shop) {
       const { id: shopId } = item.shop.item;
       const shopData = await searchShopInformationApiResponse(shopId);
@@ -36,15 +40,25 @@ const getServerSideProps = async () => {
 };
 
 const Employer = async () => {
-  const { uid, shopData, noticeList } = await getServerSideProps();
+  const { uid, item, shopData, noticeList } = await getServerSideProps();
   if (uid === undefined) {
     redirect("/signin");
   }
 
+  if (item.type === "employee") {
+    redirect("/");
+  }
+
   return (
-    <div className="mx-auto min-h-[calc(100vh-10.625rem)] max-w-[64.25rem] px-8 py-[3.75rem]">
-      <StoreDetail data={shopData} />
-      {shopData && <PostEmployer shopData={shopData} noticeList={noticeList} />}
+    <div className="flex min-h-[calc(100vh-10.625rem)] flex-col">
+      <div className="mx-auto flex w-full max-w-[64.25rem] flex-col px-8 py-[3.75rem] tab:mx-0">
+        <StoreDetail data={shopData} />
+      </div>
+      {shopData && (
+        <div className="mx-auto flex w-full justify-center bg-gray-5 px-8 py-[3.75rem]">
+          <PostEmployer shopData={shopData} noticeList={noticeList} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/employer/postTest/page.tsx
+++ b/src/app/employer/postTest/page.tsx
@@ -1,12 +1,14 @@
 import PostEmployer from "@/components/employer/PostEmployer";
+import { STORE_DETAIL_EMPLOYER } from "@/util/constants/STORE_DETAIL_EMPLOYER";
 import React from "react";
 
 type Props = {};
 
 const EmployerPostTest = (props: Props) => {
+  const data = STORE_DETAIL_EMPLOYER;
   return (
     <div className="max-w-[964px]">
-      <PostEmployer />
+      <PostEmployer data={data} />
     </div>
   );
 };

--- a/src/app/employer/postTest/page.tsx
+++ b/src/app/employer/postTest/page.tsx
@@ -7,8 +7,8 @@ type Props = {};
 const EmployerPostTest = (props: Props) => {
   const data = STORE_DETAIL_EMPLOYER;
   return (
-    <div className="max-w-[60.25rem] tab:max-w-[42.375rem] mob:max-w-[21.9375rem]">
-      <PostEmployer data={data} />
+    <div className="max-w-[60.25rem] tab:max-w-[40.375rem] mob:max-w-[21.9375rem]">
+      <PostEmployer shopData={data} />
     </div>
   );
 };

--- a/src/app/employer/postTest/page.tsx
+++ b/src/app/employer/postTest/page.tsx
@@ -7,7 +7,7 @@ type Props = {};
 const EmployerPostTest = (props: Props) => {
   const data = STORE_DETAIL_EMPLOYER;
   return (
-    <div className="max-w-[964px]">
+    <div className="max-w-[60.25rem] tab:max-w-[42.375rem] mob:max-w-[21.9375rem]">
       <PostEmployer data={data} />
     </div>
   );

--- a/src/app/employer/postTest/page.tsx
+++ b/src/app/employer/postTest/page.tsx
@@ -1,0 +1,14 @@
+import PostEmployer from "@/components/employer/PostEmployer";
+import React from "react";
+
+type Props = {};
+
+const EmployerPostTest = (props: Props) => {
+  return (
+    <div className="max-w-[964px]">
+      <PostEmployer />
+    </div>
+  );
+};
+
+export default EmployerPostTest;

--- a/src/components/common/StoreDetail/StoreDetailButtons.tsx
+++ b/src/components/common/StoreDetail/StoreDetailButtons.tsx
@@ -23,7 +23,8 @@ const StoreDetailButtons = ({
 }) => {
   const pathName = usePathname();
   const router = useRouter();
-  const isEmployerMainPage = pathName.includes("employer");
+  const isEmployerMainPage =
+    pathName.includes("employer") && !pathName.includes("notice");
 
   // 현재 유저의 유형을 파악하는 임시 함수, context 등을 이용하여 값을 읽는 식으로 할 필요가 있음.
   const isUserEmployer = true;
@@ -45,7 +46,7 @@ const StoreDetailButtons = ({
           <Button
             size="full"
             color="red"
-            onClick={() => router.push("/employer/post")}
+            onClick={() => router.push("/employer/notice")}
           >
             공고 등록하기
           </Button>
@@ -58,7 +59,7 @@ const StoreDetailButtons = ({
         <Button
           size="full"
           color="white"
-          onClick={() => router.push(`/employer/post/edit/${postId}`)}
+          onClick={() => router.push(`/employer/notice/edit/${postId}`)}
         >
           공고 편집
         </Button>

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -1,0 +1,46 @@
+import EMPLOYER_POST_LIST from "@/util/constants/EMPLOYER_POST_LIST";
+import React from "react";
+import Post from "../common/Post/Post";
+
+type Props = {};
+
+interface PostDataType {
+  id: string;
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+  closed: boolean;
+}
+
+// startTime: string;
+// startHour: string;
+
+const PostEmployer = (props: Props) => {
+  const data = EMPLOYER_POST_LIST;
+
+  function DataConvertComponentStandard(PostData: PostDataType) {
+    return {
+      imgUrl: "imgUrl",
+      shopName: "shopName",
+      address1: "address1",
+      hourlyPay: PostData.hourlyPay,
+      state: PostData.closed,
+      startTime: "asdf",
+      startHour: "asdf",
+    };
+  }
+
+  return (
+    <div>
+      <p className="h1 text-block mb-8">내가 등록한 공고</p>
+      <div className="grid grid-cols-3 gap-x-[0.875rem] gap-y-8">
+        {data.items.map((item) =>
+          Post(DataConvertComponentStandard(item.item)),
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PostEmployer;

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -15,9 +15,24 @@ interface PostDataType {
 }
 
 const PostEmployer = ({ shopData, fetchedNoticeList }: any) => {
+  const [isLastNoticeVisible, setIsLastNoticeVisible] = useState(false);
   const [noticeList, setNoticeList] = useState(
     fetchedNoticeList.items || undefined,
   );
+
+  const observeObject = useRef<HTMLDivElement>(null);
+
+  // useEffect를 이용하여 IntersectionObserver을 등록
+  useEffect(() => {
+    const lastNoticeObserver = new IntersectionObserver((entries) => {
+      entries.map((entry) => {
+        if (entry.isIntersecting) {
+          console.log("보다");
+        }
+      });
+    });
+    lastNoticeObserver.observe(observeObject.current!);
+  }, []);
 
   if (noticeList === undefined) {
     return (
@@ -33,6 +48,7 @@ const PostEmployer = ({ shopData, fetchedNoticeList }: any) => {
             </div>
           </div>
         </StoreDetailCardBorder>
+        <div className="h-[1px] w-full" ref={observeObject} />
       </div>
     );
   }
@@ -77,6 +93,7 @@ const PostEmployer = ({ shopData, fetchedNoticeList }: any) => {
           );
         })}
       </div>
+      <div className="h-[1px] w-full" ref={observeObject} />
     </div>
   );
 };

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -1,6 +1,8 @@
 import EMPLOYER_POST_LIST from "@/util/constants/EMPLOYER_POST_LIST";
 import React from "react";
 import Post from "../common/Post/Post";
+import StoreDetailCardBorder from "../common/StoreDetail/StoreDetailCardBorder";
+import Button from "../common/Button";
 
 type Props = {};
 
@@ -34,6 +36,23 @@ function formatDate(startsAt: string, workhour: number): string[] {
 
 const PostEmployer = ({ shopData }: any) => {
   const postData = EMPLOYER_POST_LIST;
+  if (postData?.items === undefined) {
+    return (
+      <div>
+        <p className="h1 text-block mob:h3 mb-8 mob:mb-4">등록한 공고</p>
+        <StoreDetailCardBorder isBgWhite={true}>
+          <div className="body1 mob:body2 flex w-full flex-col items-center justify-center gap-6">
+            공고를 등록해 보세요{" "}
+            <div className="w-[348px] mob:w-[108px]">
+              <Button size="full" color="red">
+                공고 등록하기
+              </Button>
+            </div>
+          </div>
+        </StoreDetailCardBorder>
+      </div>
+    );
+  }
 
   function dataConvertComponentStandard(PostData: PostDataType) {
     return {

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -6,6 +6,7 @@ import Button from "../common/Button";
 import { formatApiDateData } from "@/util/formatDate";
 import { getCookie } from "@/util/cookieSetting";
 import { searchShopNoticeApiResponse } from "@/util/api";
+import Link from "next/link";
 
 interface PostDataType {
   closed: boolean;
@@ -101,16 +102,17 @@ const PostEmployer = ({ shopData, fetchedNoticeList }: any) => {
             startHour,
           } = dataConvertComponentStandard(item);
           return (
-            <Post
-              imgUrl={imgUrl}
-              shopName={shopName}
-              address1={address1}
-              hourlyPay={hourlyPay}
-              state={state}
-              startTime={startTime}
-              startHour={startHour}
-              key={item.id}
-            />
+            <Link key={item.id} href={`/employer/${item.id}`}>
+              <Post
+                imgUrl={imgUrl}
+                shopName={shopName}
+                address1={address1}
+                hourlyPay={hourlyPay}
+                state={state}
+                startTime={startTime}
+                startHour={startHour}
+              />
+            </Link>
           );
         })}
       </div>

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -13,9 +13,7 @@ interface PostDataType {
   closed: boolean;
 }
 
-// startTime: string;
-// startHour: string;
-
+// 임시 함수. 수환님이 공통으로 빼주신다고 하셨으니, 그전까지만 쓸 계획
 function formatDate(startsAt: string, workhour: number): string[] {
   const start = new Date(startsAt);
   const end = new Date(start.getTime() + workhour * 3600000);
@@ -37,7 +35,7 @@ function formatDate(startsAt: string, workhour: number): string[] {
 const PostEmployer = ({ data }: any) => {
   const data2 = EMPLOYER_POST_LIST;
 
-  function DataConvertComponentStandard(PostData: PostDataType) {
+  function dataConvertComponentStandard(PostData: PostDataType) {
     return {
       imgUrl: data.item.imageUrl,
       shopName: data.item.name,
@@ -51,11 +49,31 @@ const PostEmployer = ({ data }: any) => {
 
   return (
     <div>
-      <p className="h1 text-block mb-8">내가 등록한 공고</p>
-      <div className="grid grid-cols-3 gap-x-[0.875rem] gap-y-8">
-        {data2.items.map((item) =>
-          Post(DataConvertComponentStandard(item.item)),
-        )}
+      <p className="h1 text-block mob:h3 mb-8">내가 등록한 공고</p>
+      <div className="grid grid-cols-3 gap-x-[0.875rem] gap-y-8 tab:grid-cols-2">
+        {data2.items.map((item) => {
+          const {
+            imgUrl,
+            shopName,
+            address1,
+            hourlyPay,
+            state,
+            startTime,
+            startHour,
+          } = dataConvertComponentStandard(item.item);
+          return (
+            <Post
+              imgUrl={imgUrl}
+              shopName={shopName}
+              address1={address1}
+              hourlyPay={hourlyPay}
+              state={state}
+              startTime={startTime}
+              startHour={startHour}
+              key={item.item.id}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -102,7 +102,7 @@ const PostEmployer = ({ shopData, fetchedNoticeList }: any) => {
             startHour,
           } = dataConvertComponentStandard(item);
           return (
-            <Link key={item.id} href={`/employer/${item.id}`}>
+            <Link key={item.id} href={`/employer/notice/${item.id}`}>
               <Post
                 imgUrl={imgUrl}
                 shopName={shopName}

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -16,18 +16,36 @@ interface PostDataType {
 // startTime: string;
 // startHour: string;
 
-const PostEmployer = (props: Props) => {
-  const data = EMPLOYER_POST_LIST;
+function formatDate(startsAt: string, workhour: number): string[] {
+  const start = new Date(startsAt);
+  const end = new Date(start.getTime() + workhour * 3600000);
+
+  // Ensuring month and day are two digits
+  const formattedMonth = (start.getMonth() + 1).toString().padStart(2, "0");
+  const formattedDay = start.getDate().toString().padStart(2, "0");
+  const formattedStartHours = start.getHours().toString().padStart(2, "0");
+  const formattedStartMinutes = start.getMinutes().toString().padStart(2, "0");
+  const formattedEndHours = end.getHours().toString().padStart(2, "0");
+  const formattedEndMinutes = end.getMinutes().toString().padStart(2, "0");
+
+  return [
+    `${start.getFullYear()}-${formattedMonth}-${formattedDay}`,
+    `${formattedStartHours}:${formattedStartMinutes}~${formattedEndHours}:${formattedEndMinutes} (${workhour}시간)`,
+  ];
+}
+
+const PostEmployer = ({ data }: any) => {
+  const data2 = EMPLOYER_POST_LIST;
 
   function DataConvertComponentStandard(PostData: PostDataType) {
     return {
-      imgUrl: "imgUrl",
-      shopName: "shopName",
-      address1: "address1",
+      imgUrl: data.item.imageUrl,
+      shopName: data.item.name,
+      address1: data.item.address1,
       hourlyPay: PostData.hourlyPay,
       state: PostData.closed,
-      startTime: "asdf",
-      startHour: "asdf",
+      startTime: formatDate(PostData.startsAt, PostData.workhour)[0],
+      startHour: formatDate(PostData.startsAt, PostData.workhour)[1],
     };
   }
 
@@ -35,7 +53,7 @@ const PostEmployer = (props: Props) => {
     <div>
       <p className="h1 text-block mb-8">내가 등록한 공고</p>
       <div className="grid grid-cols-3 gap-x-[0.875rem] gap-y-8">
-        {data.items.map((item) =>
+        {data2.items.map((item) =>
           Post(DataConvertComponentStandard(item.item)),
         )}
       </div>

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Post from "../common/Post/Post";
 import StoreDetailCardBorder from "../common/StoreDetail/StoreDetailCardBorder";
 import Button from "../common/Button";
+import { formatApiDateData } from "@/util/formatDate";
 
 type Props = {};
 
@@ -15,27 +16,9 @@ interface PostDataType {
   closed: boolean;
 }
 
-// 임시 함수. 수환님이 공통으로 빼주신다고 하셨으니, 그전까지만 쓸 계획
-function formatDate(startsAt: string, workhour: number): string[] {
-  const start = new Date(startsAt);
-  const end = new Date(start.getTime() + workhour * 3600000);
-
-  // Ensuring month and day are two digits
-  const formattedMonth = (start.getMonth() + 1).toString().padStart(2, "0");
-  const formattedDay = start.getDate().toString().padStart(2, "0");
-  const formattedStartHours = start.getHours().toString().padStart(2, "0");
-  const formattedStartMinutes = start.getMinutes().toString().padStart(2, "0");
-  const formattedEndHours = end.getHours().toString().padStart(2, "0");
-  const formattedEndMinutes = end.getMinutes().toString().padStart(2, "0");
-
-  return [
-    `${start.getFullYear()}-${formattedMonth}-${formattedDay}`,
-    `${formattedStartHours}:${formattedStartMinutes}~${formattedEndHours}:${formattedEndMinutes} (${workhour}시간)`,
-  ];
-}
-
-const PostEmployer = ({ shopData }: any) => {
-  const postData = EMPLOYER_POST_LIST;
+const PostEmployer = ({ shopData, noticeList }: any) => {
+  const postData = noticeList;
+  console.log(noticeList);
   if (postData?.items === undefined) {
     return (
       <div>
@@ -61,8 +44,8 @@ const PostEmployer = ({ shopData }: any) => {
       address1: shopData.item.address1,
       hourlyPay: PostData.hourlyPay,
       state: PostData.closed,
-      startTime: formatDate(PostData.startsAt, PostData.workhour)[0],
-      startHour: formatDate(PostData.startsAt, PostData.workhour)[1],
+      startTime: formatApiDateData(PostData.startsAt, PostData.workhour)[0],
+      startHour: formatApiDateData(PostData.startsAt, PostData.workhour)[1],
     };
   }
 

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -1,25 +1,25 @@
-import EMPLOYER_POST_LIST from "@/util/constants/EMPLOYER_POST_LIST";
-import React from "react";
+"use client";
+import React, { useEffect, useRef, useState } from "react";
 import Post from "../common/Post/Post";
 import StoreDetailCardBorder from "../common/StoreDetail/StoreDetailCardBorder";
 import Button from "../common/Button";
 import { formatApiDateData } from "@/util/formatDate";
 
-type Props = {};
-
 interface PostDataType {
-  id: string;
+  closed: boolean;
+  description: string;
   hourlyPay: number;
+  id: string;
   startsAt: string;
   workhour: number;
-  description: string;
-  closed: boolean;
 }
 
-const PostEmployer = ({ shopData, noticeList }: any) => {
-  const postData = noticeList;
-  console.log(noticeList);
-  if (postData?.items === undefined) {
+const PostEmployer = ({ shopData, fetchedNoticeList }: any) => {
+  const [noticeList, setNoticeList] = useState(
+    fetchedNoticeList.items || undefined,
+  );
+
+  if (noticeList === undefined) {
     return (
       <div>
         <p className="h1 text-block mob:h3 mb-8 mob:mb-4">등록한 공고</p>
@@ -53,7 +53,7 @@ const PostEmployer = ({ shopData, noticeList }: any) => {
     <div>
       <p className="h1 text-block mob:h3 mb-8">내가 등록한 공고</p>
       <div className="grid grid-cols-3 gap-x-[0.875rem] gap-y-8 tab:grid-cols-2">
-        {postData.items.map((item) => {
+        {noticeList.map(({ item }: { item: PostDataType }) => {
           const {
             imgUrl,
             shopName,
@@ -62,7 +62,7 @@ const PostEmployer = ({ shopData, noticeList }: any) => {
             state,
             startTime,
             startHour,
-          } = dataConvertComponentStandard(item.item);
+          } = dataConvertComponentStandard(item);
           return (
             <Post
               imgUrl={imgUrl}
@@ -72,7 +72,7 @@ const PostEmployer = ({ shopData, noticeList }: any) => {
               state={state}
               startTime={startTime}
               startHour={startHour}
-              key={item.item.id}
+              key={item.id}
             />
           );
         })}

--- a/src/components/employer/PostEmployer.tsx
+++ b/src/components/employer/PostEmployer.tsx
@@ -32,14 +32,14 @@ function formatDate(startsAt: string, workhour: number): string[] {
   ];
 }
 
-const PostEmployer = ({ data }: any) => {
-  const data2 = EMPLOYER_POST_LIST;
+const PostEmployer = ({ shopData }: any) => {
+  const postData = EMPLOYER_POST_LIST;
 
   function dataConvertComponentStandard(PostData: PostDataType) {
     return {
-      imgUrl: data.item.imageUrl,
-      shopName: data.item.name,
-      address1: data.item.address1,
+      imgUrl: shopData.item.imageUrl,
+      shopName: shopData.item.name,
+      address1: shopData.item.address1,
       hourlyPay: PostData.hourlyPay,
       state: PostData.closed,
       startTime: formatDate(PostData.startsAt, PostData.workhour)[0],
@@ -51,7 +51,7 @@ const PostEmployer = ({ data }: any) => {
     <div>
       <p className="h1 text-block mob:h3 mb-8">내가 등록한 공고</p>
       <div className="grid grid-cols-3 gap-x-[0.875rem] gap-y-8 tab:grid-cols-2">
-        {data2.items.map((item) => {
+        {postData.items.map((item) => {
           const {
             imgUrl,
             shopName,

--- a/src/util/constants/EMPLOYER_POST_LIST.ts
+++ b/src/util/constants/EMPLOYER_POST_LIST.ts
@@ -1,0 +1,348 @@
+const EMPLOYER_POST_LIST = {
+  offset: 0,
+  limit: 10,
+  count: 10,
+  hasNext: false,
+  items: [
+    {
+      item: {
+        id: "6fa67d08-de36-4b13-b085-e530d43f65a3",
+        hourlyPay: 500000,
+        startsAt: "2024-05-01T00:00:00.000Z",
+        workhour: 5,
+        description: "string",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/6fa67d08-de36-4b13-b085-e530d43f65a3",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/6fa67d08-de36-4b13-b085-e530d43f65a3",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "9edbf970-d9a0-4504-99c5-497063c9e0b5",
+        hourlyPay: 50000,
+        startsAt: "2024-05-01T00:00:00.000Z",
+        workhour: 5,
+        description: "string",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/9edbf970-d9a0-4504-99c5-497063c9e0b5",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/9edbf970-d9a0-4504-99c5-497063c9e0b5",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "4539ab39-d627-4343-8f4d-27c4f5048d12",
+        hourlyPay: 50000,
+        startsAt: "2024-05-01T00:00:00.000Z",
+        workhour: 5,
+        description: "string",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/4539ab39-d627-4343-8f4d-27c4f5048d12",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/4539ab39-d627-4343-8f4d-27c4f5048d12",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "67646731-b41e-4318-a5de-1b9c78e22ca8",
+        hourlyPay: 50000,
+        startsAt: "2024-05-01T00:00:00.000Z",
+        workhour: 5,
+        description: "string",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/67646731-b41e-4318-a5de-1b9c78e22ca8",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/67646731-b41e-4318-a5de-1b9c78e22ca8",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "ba1e7554-0b2b-4583-9a6f-a16dae71b46a",
+        hourlyPay: 500000,
+        startsAt: "2024-05-01T00:00:00.000Z",
+        workhour: 5,
+        description: "string",
+        closed: true,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/ba1e7554-0b2b-4583-9a6f-a16dae71b46a",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "a9989e2e-253c-40ce-8ecd-6f946da626e0",
+        hourlyPay: 50000,
+        startsAt: "2024-05-01T00:00:00.000Z",
+        workhour: 5,
+        description: "string",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/a9989e2e-253c-40ce-8ecd-6f946da626e0",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/a9989e2e-253c-40ce-8ecd-6f946da626e0",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "7f642440-619b-4940-95bf-90905d6498b3",
+        hourlyPay: 100002,
+        startsAt: "2024-04-29T00:00:00Z",
+        workhour: 10,
+        description: "string",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/7f642440-619b-4940-95bf-90905d6498b3",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/7f642440-619b-4940-95bf-90905d6498b3",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "c43c080d-e036-42d0-bebd-0f62b978e04c",
+        hourlyPay: 24000,
+        startsAt: "2024-04-26T15:00:00.000Z",
+        workhour: 24,
+        description: "ㅂㅂ",
+        closed: true,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/c43c080d-e036-42d0-bebd-0f62b978e04c",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/c43c080d-e036-42d0-bebd-0f62b978e04c",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "1b12e4aa-2aeb-472a-919b-eaf102b6e7c6",
+        hourlyPay: 20000,
+        startsAt: "2024-04-18T15:00:00.000Z",
+        workhour: 12,
+        description: "주말 알바 시급",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/1b12e4aa-2aeb-472a-919b-eaf102b6e7c6",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/1b12e4aa-2aeb-472a-919b-eaf102b6e7c6",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+    {
+      item: {
+        id: "b0dc8d8a-ab60-4b99-98af-95e5bbeefbea",
+        hourlyPay: 15000,
+        startsAt: "2024-04-12T15:00:00.000Z",
+        workhour: 12,
+        description: "시간은 길지만 편해유",
+        closed: false,
+      },
+      links: [
+        {
+          rel: "self",
+          description: "공고 정보",
+          method: "GET",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/b0dc8d8a-ab60-4b99-98af-95e5bbeefbea",
+        },
+        {
+          rel: "update",
+          description: "공고 수정",
+          method: "PUT",
+          href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices/b0dc8d8a-ab60-4b99-98af-95e5bbeefbea",
+          body: {
+            hourlyPay: "number",
+            startsAt: "string",
+            workhour: "number",
+            description: "string",
+          },
+        },
+      ],
+    },
+  ],
+  links: [
+    {
+      ref: "self",
+      description: "현재 페이지",
+      method: "GET",
+      href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices?offset=0&limit=10",
+    },
+    {
+      rel: "prev",
+      description: "이전 페이지",
+      method: "GET",
+      href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices?offset=0&limit=10",
+    },
+    {
+      rel: "next",
+      description: "다음 페이지",
+      method: "GET",
+      href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices?offset=10&limit=10",
+    },
+    {
+      rel: "create",
+      description: "공고 생성",
+      method: "POST",
+      href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57/notices",
+      body: {
+        hourlyPay: "number",
+        startsAt: "string",
+        workhour: "number",
+        description: "string",
+      },
+    },
+    {
+      rel: "shop",
+      description: "가게 정보",
+      method: "GET",
+      href: "/api/0-1/the-julge/shops/52200d57-25a3-4910-9903-e524d1d67a57",
+    },
+  ],
+};
+
+export default EMPLOYER_POST_LIST;


### PR DESCRIPTION
## 🚀 작업 내용

- 사장이 등록한 공고의 무한 스크롤 관련 기능을 가진 컴포넌트를 작성하였습니다.

## 📝 참고 사항

- 현재 로드된 공고 리스트의 state 갱신 기능을 (prev)콜백으로 시행하면 strict모드의 영향인지, 혹시모를 버그의 영향인지 두번 불러와지는 현상이 있습니다. 이를 방지하기 위해, 기존 리스트를 먼저 정의하고, 나중에 불러온 리스트를 추가로 갱신하는 형태를 취했습니다.
- 추가로, 사장의 공고 상세 페이지에서 발생한 일부 버그를 고쳤습니다.

## 🖼️ 스크린샷
### 무한 스크롤 발동 전입니다.
<img width="1225" alt="스크린샷 2024-04-24 오후 1 59 38" src="https://github.com/royxk/codeit_team5_project/assets/155033024/6427df5e-fd1f-4c51-afd7-87d076785ac9">

### 무한 스크롤 발동 후 스크롤이 늘어난 모습입니다.
<img width="1227" alt="스크린샷 2024-04-24 오후 1 59 57" src="https://github.com/royxk/codeit_team5_project/assets/155033024/3cff786b-4c16-4466-9bde-9597f31512ec">

### 중복없이 6개 + 5개, 총 11개가 불러와진 모습입니다.
<img width="1067" alt="스크린샷 2024-04-24 오후 2 15 07" src="https://github.com/royxk/codeit_team5_project/assets/155033024/e5765f05-d3fb-4c7d-9298-75ffd88930c3">
<img width="1213" alt="스크린샷 2024-04-24 오후 2 00 16" src="https://github.com/royxk/codeit_team5_project/assets/155033024/64ced851-a0c0-4b8c-93da-99b2fbd272d4">


## 🚨 관련 이슈

- StoreDetail Button 컴포넌트에 건드린 부분이 조금 있습니다. 간단한 string 수정이므로 충돌이 난다고 당황하지 말아주세요.
