### PR TITLE
[PTTF-65] ♻️ GNB 로그인, 회원가입 페이지에 보이지 않도록 수정

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import React from "react";
+
+type Props = {};
+
+const NotFound = (props: Props) => {
+  return (
+    <>
+      <div className="absolute top-0 z-[100] flex h-full w-full flex-col items-center justify-center bg-red-10 text-6xl text-black">
+        죄송합니다. 해당 페이지를 찾을 수 없습니다.
+        <Link className="mt-5 text-base underline" href={"/"}>
+          메인 페이지로 돌아가기
+        </Link>
+      </div>
+    </>
+  );
+};
+export default NotFound;

--- a/src/components/common/GNB.tsx
+++ b/src/components/common/GNB.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import NotificationModalComponent from "./NotificationModal/NotificationModalComponent";
 import SearchSvg from "./GNB/SearchSvg";
@@ -8,12 +8,31 @@ import { getCookie } from "@/util/cookieSetting";
 import { usePathname } from "next/navigation";
 
 const GNB = () => {
-  const isLogin = getCookie("accessToken");
-  const isEmployer = getCookie("sid");
-
+  const pathname = usePathname();
+  const isSign = pathname.includes("sign");
+  const [isLogin, setIsLogin] = useState(false);
+  const [isEmployer, setIsEmployer] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const pathName = usePathname();
-  const isFooterHidden = pathName.includes("sign");
-  if (isFooterHidden) return;
+
+  useEffect(() => {
+    setIsLoading(true);
+
+    if (getCookie("accessToken")) {
+      setIsLogin(true);
+    } else {
+      setIsLogin(false);
+    }
+
+    if (getCookie("sid")) {
+      setIsEmployer(true);
+    } else {
+      setIsEmployer(false);
+    }
+    setIsLoading(false);
+  }, [pathName]);
+
+  if (isSign) return;
 
   return (
     <div className="flex h-[70px] w-full items-center justify-center mob:h-[102px] mob:px-3">
@@ -39,23 +58,49 @@ const GNB = () => {
               </div>
             </div>
           </div>
-          {isLogin ? (
-            <div className="flex gap-10 mob:absolute mob:right-5 mob:top-4 mob:gap-4 mob:text-sm">
-              <button className="flex h-5 font-bold text-black">
-                {isEmployer ? "내 가게" : "내 프로필"}
-              </button>
-              <button className="flex h-5 font-bold text-black">
-                로그아웃
-              </button>
-              <NotificationModalComponent />
-            </div>
+          {isLoading ? (
+            <></>
           ) : (
-            <div className="flex gap-10 mob:absolute mob:right-5 mob:top-4 mob:gap-4 mob:text-sm">
-              <button className="flex h-5 font-bold text-black">로그인</button>
-              <button className="flex h-5 font-bold text-black">
-                회원 가입
-              </button>
-            </div>
+            <>
+              {isLogin ? (
+                <div
+                  className="flex gap-10 mob:absolute mob:right-5 mob:top-4 mob:gap-4 mob:text-sm"
+                  suppressHydrationWarning
+                >
+                  <button
+                    className="flex h-5 font-bold text-black"
+                    suppressHydrationWarning
+                  >
+                    {isEmployer ? "내 가게" : "내 프로필"}
+                  </button>
+                  <button
+                    className="flex h-5 font-bold text-black"
+                    suppressHydrationWarning
+                  >
+                    로그아웃
+                  </button>
+                  <NotificationModalComponent />
+                </div>
+              ) : (
+                <div
+                  className="flex gap-10 mob:absolute mob:right-5 mob:top-4 mob:gap-4 mob:text-sm"
+                  suppressHydrationWarning
+                >
+                  <button
+                    className="flex h-5 font-bold text-black"
+                    suppressHydrationWarning
+                  >
+                    로그인
+                  </button>
+                  <button
+                    className="flex h-5 font-bold text-black"
+                    suppressHydrationWarning
+                  >
+                    회원 가입
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/components/common/GNB.tsx
+++ b/src/components/common/GNB.tsx
@@ -1,13 +1,19 @@
+"use client";
 import React from "react";
 import Link from "next/link";
 import NotificationModalComponent from "./NotificationModal/NotificationModalComponent";
 import SearchSvg from "./GNB/SearchSvg";
 import LogoSvg from "./GNB/LogoSvg";
-import { getServerSideCookie } from "@/app/utils/serverCookies";
+import { getCookie } from "@/util/cookieSetting";
+import { usePathname } from "next/navigation";
 
 const GNB = () => {
-  const isLogin = getServerSideCookie("accessToken");
-  const isEmployer = getServerSideCookie("sid");
+  const isLogin = getCookie("accessToken");
+  const isEmployer = getCookie("sid");
+
+  const pathName = usePathname();
+  const isFooterHidden = pathName.includes("sign");
+  if (isFooterHidden) return;
 
   return (
     <div className="flex h-[70px] w-full items-center justify-center mob:h-[102px] mob:px-3">


### PR DESCRIPTION
## 🚀 작업 내용

- 로그인, 회원가입 페이지에는 GNB가 보이지 않도록 수정했고 그 과정에서 쿠키 관련 코드도 다시 변경했습니다.
- 관련 로직에 로딩중 상태일때를 추가하여 상태에 따라 다르게 랜더링 될 뿐 아니라 로딩중일떄는 아무것도 나오지 않다가 로딩 된 후 마지막에 결정된 사항이 보이면서 처음에 '로그인' 이었다가 나중에 '내 가게' 혹은 '내 프로필' 이 나오는 현상을 제거 했습니다.
- 추가적으로 not-found페이지 임시로 작성하여 올렸습니다.

## 📝 참고 사항

- 서버 사이드에서 해보려고 했으나 hydration 에러가 발생하여 결국 useEffect로 상태 관리를 통해 개발 할 수 밖에 없었습니다.
- 현재 notfound 페이지도 gnb와 layout이 나오고 있어서 우선 absolute 사용하여 보이지 않도록 처리 하였는데 이 부분에 관해 1시간 가량 찾아도 답이 안 나와서 우선 이렇게 적용했습니다. 겉보기에는 아무런 문제가 없긴 합니다.

## 🖼️ 스크린샷

![image](https://github.com/royxk/codeit_team5_project/assets/155133655/50246741-b87c-490b-a211-6ccf4e923746)
![image](https://github.com/royxk/codeit_team5_project/assets/155133655/47329bc6-bcb4-40d4-95df-460cfa073944)
![image](https://github.com/royxk/codeit_team5_project/assets/155133655/1c1dfed1-b427-4b16-9cdd-576568ba0bf0)


## 🚨 관련 이슈

-
