### PR TITLE
[PTTF-72] table 컴포넌트 재수정 및 ApproveButtons 컴포넌트 수정

### DIFF
--- a/src/app/employee/page.tsx
+++ b/src/app/employee/page.tsx
@@ -32,7 +32,7 @@ const Employee = async () => {
       </div>
     {!isProfileData && 
       <div className="flex flex-col justify-start items-center bg-gray-5 pt-[60px] pb-[120px] tab:-mx-8 mob:-mx-3 mob:pt-10 mob:pb-20">
-        <div className="flex flex-col gap-8 tab:w-[632px] mob:w-[350px] mob:gap-4">
+        <div className="flex flex-col gap-8 w-[964px] tab:w-[632px] mob:w-[350px] mob:gap-4">
           <h1 className="h1 mob:h2">신청 내역</h1>
           <EmployeeTable />
         </div>

--- a/src/components/ProfileDetail/profileHeader.tsx
+++ b/src/components/ProfileDetail/profileHeader.tsx
@@ -37,7 +37,7 @@ const ProfileHeader = ({ isProfileData }: ProfileHeaderProps) => {
       <div className="flex flex-col items-center gap-6 w-[964px] border border-gray-20 rounded-lg px-6 py-[60px] tab:w-[632px] mob:text-sm mob:w-[350px]">
         <p className="text-black">내 프로필을 등록하고 원하는 가게에 지원해 보세요</p>
         <Link href="/employee/my-profile">
-          <Button size="large" color="red" className="mob:px-5 py-[10px] text-sm">내 프로필 등록하기</Button>
+          <Button size="large" color="red" className="mob:px-5 mob:py-[10px] mob:text-sm">내 프로필 등록하기</Button>
         </Link>
       </div>
     :

--- a/src/components/common/ApproveButtons.tsx
+++ b/src/components/common/ApproveButtons.tsx
@@ -1,12 +1,27 @@
 'use client';
+import { StatusBody, selectedNoticeApplyStatusSettingApiResponse } from "@/util/api";
+import { useParams } from "next/navigation";
+import { MouseEvent } from "react";
 
-const ApproveButtons = () => {
-  const handleClick = () => {
-    return alert('버튼 클릭!')
+interface ApproveButtonsProps {
+  noticeApplyId: string;
+}
+
+const ApproveButtons = ({ noticeApplyId }: ApproveButtonsProps) => {
+  const { shopId, noticeId } = useParams<{ shopId: string; noticeId: string }>();
+  const handleClick = async (e: MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+    const body = {
+      "status": button.id,
+    } as StatusBody
+    // await selectedNoticeApplyStatusSettingApiResponse(shopId, noticeId, noticeApplyId, body);
+    return alert(`거절하기 버튼 클릭! apply_id=${noticeApplyId} ${button.id}`)
   }
+
   return (
     <div className='flex gap-3 mob:gap-2'>
       <button
+        id="rejected"
         className='flex items-center bg-white text-primary border border-primary rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-red-10 mob:font-normal mob:text-xs mob:px-3 mob:py-2 mob:h-8'
         type='button'
         onClick={handleClick}
@@ -14,6 +29,7 @@ const ApproveButtons = () => {
         거절하기
       </button>
       <button
+        id="accepted"
         className='flex items-center bg-white text-blue-20 border border-blue-20 rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-blue-10 mob:font-normal mob:text-xs mob:px-3 mob:py-2 mob:h-8'
         type='button'
         onClick={handleClick}

--- a/src/components/common/ApproveButtons.tsx
+++ b/src/components/common/ApproveButtons.tsx
@@ -1,43 +1,91 @@
 'use client';
 import { StatusBody, selectedNoticeApplyStatusSettingApiResponse } from "@/util/api";
 import { useParams } from "next/navigation";
-import { MouseEvent } from "react";
+import { MouseEvent, useState } from "react";
+import Modal from "../signin/Modal";
+import Button from "./Button";
 
 interface ApproveButtonsProps {
   noticeApplyId: string;
 }
 
+const MODAL_MESSAGE = [
+  "신청을 거절하시겠어요?",
+  "신청을 승인하시겠어요?",
+]
+
 const ApproveButtons = ({ noticeApplyId }: ApproveButtonsProps) => {
+  const [showModal, setShowModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+  const [reqBody, setReqBody] = useState({})
   const { shopId, noticeId } = useParams<{ shopId: string; noticeId: string }>();
-  const handleClick = async (e: MouseEvent<HTMLButtonElement>) => {
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     const button = e.target as HTMLButtonElement;
     const body = {
       "status": button.id,
     } as StatusBody
-    // await selectedNoticeApplyStatusSettingApiResponse(shopId, noticeId, noticeApplyId, body);
-    return alert(`거절하기 버튼 클릭! apply_id=${noticeApplyId} ${button.id}`)
+    setReqBody(body);
+    setShowModal(true);
+    button.id === "rejected" ? setModalMessage(MODAL_MESSAGE[0]) : setModalMessage(MODAL_MESSAGE[1]);
+  }
+
+  const handleYesBtnClick = async () => {
+    setShowModal(false);
+    // await selectedNoticeApplyStatusSettingApiResponse(shopId, noticeId, noticeApplyId, reqBody);
+    console.log("리퀘스트 보냄!")
+  }
+
+  const handleNoBtnClick = () => {
+    setShowModal(false);
   }
 
   return (
-    <div className='flex gap-3 mob:gap-2'>
-      <button
-        id="rejected"
-        className='flex items-center bg-white text-primary border border-primary rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-red-10 mob:font-normal mob:text-xs mob:px-3 mob:py-2 mob:h-8'
-        type='button'
-        onClick={handleClick}
-      >
-        거절하기
-      </button>
-      <button
-        id="accepted"
-        className='flex items-center bg-white text-blue-20 border border-blue-20 rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-blue-10 mob:font-normal mob:text-xs mob:px-3 mob:py-2 mob:h-8'
-        type='button'
-        onClick={handleClick}
-      >
-        승인하기
-      </button>
-    </div>
+    <>
+      <div className='flex gap-3 mob:gap-2'>
+        <button
+          id="rejected"
+          className='flex items-center bg-white text-primary border border-primary rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-red-10 mob:font-normal mob:text-xs mob:px-3 mob:py-2 mob:h-8'
+          type='button'
+          onClick={handleClick}
+        >
+          거절하기
+        </button>
+        <button
+          id="accepted"
+          className='flex items-center bg-white text-blue-20 border border-blue-20 rounded-md h-[38px] px-5 py-[10px] font-bold text-sm hover:bg-blue-10 mob:font-normal mob:text-xs mob:px-3 mob:py-2 mob:h-8'
+          type='button'
+          onClick={handleClick}
+        >
+          승인하기
+        </button>
+      </div>
+      {showModal && (
+        <Modal onClose={handleNoBtnClick}>
+          <div className="flex flex-col gap-8">
+            <p className="text-center">{modalMessage}</p>
+            <div className="flex gap-2">
+              <Button
+                color="white"
+                size="small"
+                onClick={handleNoBtnClick}
+                className="h-[38px]"
+              >
+                아니오
+              </Button>
+              <Button
+                color="red"
+                size="small"
+                onClick={handleYesBtnClick}
+                className="h-[38px]"
+              >
+                확인
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </>
   );
-};
-
+}
 export default ApproveButtons;

--- a/src/components/common/ApproveButtons.tsx
+++ b/src/components/common/ApproveButtons.tsx
@@ -40,6 +40,10 @@ const ApproveButtons = ({ noticeApplyId }: ApproveButtonsProps) => {
     setShowModal(false);
   }
 
+  const handleOutsideClick = (e: MouseEvent<HTMLDivElement>) => {
+    setShowModal(false);
+  }
+
   return (
     <>
       <div className='flex gap-3 mob:gap-2'>
@@ -61,7 +65,7 @@ const ApproveButtons = ({ noticeApplyId }: ApproveButtonsProps) => {
         </button>
       </div>
       {showModal && (
-        <Modal onClose={handleNoBtnClick}>
+        <Modal onClose={handleOutsideClick}>
           <div className="flex flex-col gap-8">
             <p className="text-center">{modalMessage}</p>
             <div className="flex gap-2">

--- a/src/components/common/ApproveButtons.tsx
+++ b/src/components/common/ApproveButtons.tsx
@@ -40,9 +40,10 @@ const ApproveButtons = ({ noticeApplyId }: ApproveButtonsProps) => {
     setShowModal(false);
   }
 
-  const handleOutsideClick = (e: MouseEvent<HTMLDivElement>) => {
-    setShowModal(false);
-  }
+  // 모달 컴포넌트 수정될 때까지 대기
+  // const handleOutsideClick = (e: MouseEvent<HTMLDivElement>) => {
+  //   setShowModal(false);
+  // }
 
   return (
     <>
@@ -65,7 +66,7 @@ const ApproveButtons = ({ noticeApplyId }: ApproveButtonsProps) => {
         </button>
       </div>
       {showModal && (
-        <Modal onClose={handleOutsideClick}>
+        <Modal onClose={() => setShowModal(false)}>
           <div className="flex flex-col gap-8">
             <p className="text-center">{modalMessage}</p>
             <div className="flex gap-2">

--- a/src/components/common/EmployeeTable.tsx
+++ b/src/components/common/EmployeeTable.tsx
@@ -3,19 +3,31 @@ import { EmployeeTableData, convertEmployeeTableData } from "@/util/convertData"
 import Table from "./Table";
 import Button from "./Button";
 import Link from "next/link";
+import { getServerSideCookie } from "@/app/utils/serverCookies";
+import { searchUserApplyApiResponse } from "@/util/api";
 
 const EMPLOYEE_TABLE_HEADER = ['가게', '일자', '시급', '상태'];
 
-const EmployeeTable = () => {
-  const employeeData: EmployeeTableData[] = convertEmployeeTableData(SHOP_APPLY_API_RESPONSE_DATA);
+const getServerSideData = async () => {
+  const uid = getServerSideCookie("uid");
+  if (uid) {
+    const applyData = await searchUserApplyApiResponse(uid);
+    return applyData;
+  }
+  return;
+}
+
+const EmployeeTable = async () => {
+  const applyData = await getServerSideData();
+  const employeeData: EmployeeTableData[] = convertEmployeeTableData(applyData);
 
   return (
     employeeData.length ? <Table<EmployeeTableData> headerData={EMPLOYEE_TABLE_HEADER} applyData={employeeData} />
     :
-    <div className="flex flex-col items-center gap-6 w-full max-w-[964px] border border-gray-20 rounded-lg px-6 py-[60px] mob:text-sm">
+    <div className="flex flex-col items-center gap-6 w-full max-w-[964px] border border-gray-20 rounded-lg px-6 py-[60px] mob:text-sm mob:gap-4">
       <p className="text-black">아직 신청 내역이 없어요.</p>
       <Link href="/">
-        <Button size="large" color="red">공고 보러가기</Button>
+        <Button size="large" color="red" className="mob:px-5 mob:py-[10px] mob:text-sm">공고 보러가기</Button>
       </Link>
     </div>
   );

--- a/src/components/common/EmployerTable.tsx
+++ b/src/components/common/EmployerTable.tsx
@@ -1,8 +1,21 @@
 import { EmployerTableData, convertEmployerTableData } from "@/util/convertData";
 import { USER_API_RESPONSE } from "@/util/constants/table_mock_data";
 import Table from "./Table";
+import { getServerSideCookie } from "@/app/utils/serverCookies";
+import { searchSelectedNoticeApplyApiResponse } from "@/util/api";
 
 const EMPLOYER_TABLE_HEADER = ['신청자', '소개', '전화번호', '상태'];
+
+// 공고 상세 페이지 개설 시 할 예정
+// const getServerSideData = async () => {
+//   const sid = getServerSideCookie("sid");
+//   const noticeId = '';
+//   if (sid) {
+//     const applyData = await searchSelectedNoticeApplyApiResponse(sid, noticeId);
+//     return applyData;
+//   }
+//   return;
+// }
 
 const EmployerTable = () => {
   const employerData: EmployerTableData[] = convertEmployerTableData(USER_API_RESPONSE);

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -82,7 +82,7 @@ const Table = <T extends ApplyData>({
                   </td>
                   <td className="w-full min-w-[236px] bg-white pl-3 mob:min-w-[168px]">
                     {!isEmployee && status === "pending" ? (
-                      <ApproveButtons />
+                      <ApproveButtons noticeApplyId={apply_id}/>
                     ) : (
                       <StatusLabel status={status} />
                     )}

--- a/src/util/convertData.ts
+++ b/src/util/convertData.ts
@@ -26,6 +26,7 @@ type ApplyListApiResponse = {
 type ApplicantListApiResponse = {
   items: {
     item: {
+      id: string;
       status: string;
       user: {
         item: {
@@ -81,9 +82,9 @@ export const convertEmployerTableData = (
 ): EmployerTableData[] => {
   if (!responseData.items) return [];
   return responseData.items.map((data) => {
-    const { user, status } = data.item;
+    const { id, user, status } = data.item;
     return {
-      apply_id: user.item.id,
+      apply_id: id,
       userName: user.item.name,
       phoneNumber: user.item.phone,
       bio: user.item.bio,

--- a/src/util/convertData.ts
+++ b/src/util/convertData.ts
@@ -63,7 +63,7 @@ export interface EmployerTableData extends CommonData {
 export const convertEmployeeTableData = (
   responseData: ApplyListApiResponse,
 ): EmployeeTableData[] => {
-  if (!responseData.items) return [];
+  if (!responseData?.items) return [];
   return responseData.items.map((data) => {
     const { id, shop, notice, status } = data.item;
     return {
@@ -80,7 +80,7 @@ export const convertEmployeeTableData = (
 export const convertEmployerTableData = (
   responseData: ApplicantListApiResponse,
 ): EmployerTableData[] => {
-  if (!responseData.items) return [];
+  if (!responseData?.items) return [];
   return responseData.items.map((data) => {
     const { id, user, status } = data.item;
     return {

--- a/src/util/convertData.ts
+++ b/src/util/convertData.ts
@@ -62,6 +62,7 @@ export interface EmployerTableData extends CommonData {
 export const convertEmployeeTableData = (
   responseData: ApplyListApiResponse,
 ): EmployeeTableData[] => {
+  if (!responseData.items) return [];
   return responseData.items.map((data) => {
     const { id, shop, notice, status } = data.item;
     return {
@@ -78,6 +79,7 @@ export const convertEmployeeTableData = (
 export const convertEmployerTableData = (
   responseData: ApplicantListApiResponse,
 ): EmployerTableData[] => {
+  if (!responseData.items) return [];
   return responseData.items.map((data) => {
     const { user, status } = data.item;
     return {


### PR DESCRIPTION
## 🚀 작업 내용

- EmployeeTable에 사용될 데이터를 api 함수를 통해 불러왔습니다.
- EmployerTable에도 사용될 데이터를 api 함수로 구현해두었습니다.
- ApproveButtons 컴포넌트에서 버튼 클릭 시 모달 창이 뜨고 해당 버튼에 따라 동작을 구현했습니다.

## 📝 참고 사항

- EmployerTable에서 공고 상세 페이지에서 가져와야하는 값이 있는데, 아직 사장님 공고 상세 페이지의 경로가 어떻게 구현되어있는지 몰라서 작성해둔 api 함수는 주석처리 해두었습니다. 추후에 다시 수정할 예정입니다.
- EmployerTable에서 noticeApplyId를 가져와야 하기 때문에 convertData 파일에서 convertEmployerTableData 함수의 리턴 값이 수정되었습니다.
- EmployeeTable/EmployerTable 에서 api로 데이터를 불러왔을 때 items 배열이 빈 배열일 수 있음에 따라 에러가 발생하기에 그에 따른 처리를 해주었습니다.
- 모달 창이 수정 전이라 임시로 모달 컴포넌트를 가져와 구현했습니다. 디자인은 아직 미완인 점 감안해주시길 바랍니다.

## 🖼️ 스크린샷

- 거절하기 클릭
![스크린샷 2024-04-25 183411](https://github.com/royxk/codeit_team5_project/assets/155137866/9dae101d-0c34-4869-a028-4e3d9d87b85b)

- 승인하기 클릭
![스크린샷 2024-04-25 183416](https://github.com/royxk/codeit_team5_project/assets/155137866/e24aa1b0-f80b-4b22-b82b-74476dd981b4)

- api 함수 연동된 모습(아직 신청 내역이 없어 공고 보러가기 버튼이 뜹니다.)
![스크린샷 2024-04-25 184235](https://github.com/royxk/codeit_team5_project/assets/155137866/3c3819ca-367d-4be3-bf81-ce10a674502c)


## 🚨 관련 이슈

- 현재 모달 창이 수정 중에 있습니다. 연준님께서 모달 컴포넌트 수정을 완료해주시면 곧바로 모달 창의 디자인을 바꿀 예정입니다.
