### PR TITLE
[PTTF-76] 사장 페이지의 공고 등록 및 수정 관련 기능 

### DIFF
--- a/src/app/employer/notice/[noticeId]/edit/page.tsx
+++ b/src/app/employer/notice/[noticeId]/edit/page.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import EmployerNoticeForm from "@/components/employer/EmployerNoticeForm";
 import FormCloseButton from "@/components/employer/FormCloseButton";
+import { headers } from "next/headers";
 
-const EmployerNoticeRegister = async () => {
+const EmployerNoticeRegister = () => {
   return (
     <div className="min-h-[calc(100vh-170px)] w-full bg-gray-5">
       <main className="mx-auto max-w-[64.25rem] px-8 py-[3.75rem]">
         <h1 className="h1 mb-8 flex justify-between">
-          공고 수정 <FormCloseButton redirectRoute="../employer" />
+          공고 수정 <FormCloseButton />
         </h1>
         <EmployerNoticeForm />
       </main>

--- a/src/app/employer/notice/[noticeId]/edit/page.tsx
+++ b/src/app/employer/notice/[noticeId]/edit/page.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import EmployerNoticeForm from "@/components/employer/EmployerNoticeForm";
+import FormCloseButton from "@/components/employer/FormCloseButton";
+
+const EmployerNoticeRegister = async () => {
+  return (
+    <div className="min-h-[calc(100vh-170px)] w-full bg-gray-5">
+      <main className="mx-auto max-w-[64.25rem] px-8 py-[3.75rem]">
+        <h1 className="h1 mb-8 flex justify-between">
+          공고 수정 <FormCloseButton redirectRoute="../employer" />
+        </h1>
+        <EmployerNoticeForm />
+      </main>
+    </div>
+  );
+};
+
+export default EmployerNoticeRegister;

--- a/src/app/employer/notice/[noticeId]/edit/page.tsx
+++ b/src/app/employer/notice/[noticeId]/edit/page.tsx
@@ -7,7 +7,7 @@ const EmployerNoticeRegister = () => {
   return (
     <div className="min-h-[calc(100vh-170px)] w-full bg-gray-5">
       <main className="mx-auto max-w-[64.25rem] px-8 py-[3.75rem]">
-        <h1 className="h1 mb-8 flex justify-between">
+        <h1 className="h1 mob:h3 mb-8 flex justify-between">
           공고 수정 <FormCloseButton />
         </h1>
         <EmployerNoticeForm />

--- a/src/app/employer/notice/[noticeId]/page.tsx
+++ b/src/app/employer/notice/[noticeId]/page.tsx
@@ -1,13 +1,4 @@
-import { NextRequest } from "next/server";
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import Button from "@/components/common/Button";
-
 const EmployerNoticeDetailPage = () => {
-  const headersList = headers();
-  const referer = headersList.get("referer")!;
-
-  const noticeId = referer.split("notice/")[1];
   return <div className="min-h-[calc(100vh-170px)] bg-gray-5"></div>;
 };
 

--- a/src/app/employer/notice/[noticeId]/page.tsx
+++ b/src/app/employer/notice/[noticeId]/page.tsx
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import Button from "@/components/common/Button";
+
+const EmployerNoticeDetailPage = () => {
+  const headersList = headers();
+  const referer = headersList.get("referer")!;
+
+  const noticeId = referer.split("notice/")[1];
+  return <div className="min-h-[calc(100vh-170px)] bg-gray-5"></div>;
+};
+
+export default EmployerNoticeDetailPage;

--- a/src/app/employer/notice/page.tsx
+++ b/src/app/employer/notice/page.tsx
@@ -6,7 +6,7 @@ const EmployerNoticeRegister = () => {
   return (
     <div className="min-h-[calc(100vh-170px)] w-full bg-gray-5">
       <main className="mx-auto max-w-[64.25rem] px-8 py-[3.75rem]">
-        <h1 className="h1 mb-8 flex justify-between">
+        <h1 className="h1 mob:h3 mb-8 flex justify-between">
           공고 등록 <FormCloseButton />
         </h1>
         <EmployerNoticeForm />

--- a/src/app/employer/notice/page.tsx
+++ b/src/app/employer/notice/page.tsx
@@ -1,0 +1,20 @@
+import EmployerNoticeForm from "@/components/employer/EmployerNoticeForm";
+import FormCloseButton from "@/components/employer/FormCloseButton";
+import React from "react";
+
+type Props = {};
+
+const EmployerNoticeRegister = () => {
+  return (
+    <div className="min-h-[calc(100vh-170px)] w-full bg-gray-5">
+      <main className="mx-auto max-w-[64.25rem] px-8 py-[3.75rem]">
+        <h1 className="h1 mb-8 flex justify-between">
+          공고 등록 <FormCloseButton redirectRoute="../employer" />
+        </h1>
+        <EmployerNoticeForm />
+      </main>
+    </div>
+  );
+};
+
+export default EmployerNoticeRegister;

--- a/src/app/employer/notice/page.tsx
+++ b/src/app/employer/notice/page.tsx
@@ -7,7 +7,7 @@ const EmployerNoticeRegister = () => {
     <div className="min-h-[calc(100vh-170px)] w-full bg-gray-5">
       <main className="mx-auto max-w-[64.25rem] px-8 py-[3.75rem]">
         <h1 className="h1 mb-8 flex justify-between">
-          공고 등록 <FormCloseButton redirectRoute="../employer" />
+          공고 등록 <FormCloseButton />
         </h1>
         <EmployerNoticeForm />
       </main>

--- a/src/app/employer/notice/page.tsx
+++ b/src/app/employer/notice/page.tsx
@@ -2,8 +2,6 @@ import EmployerNoticeForm from "@/components/employer/EmployerNoticeForm";
 import FormCloseButton from "@/components/employer/FormCloseButton";
 import React from "react";
 
-type Props = {};
-
 const EmployerNoticeRegister = () => {
   return (
     <div className="min-h-[calc(100vh-170px)] w-full bg-gray-5">

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/util/api";
 import { getCookie } from "@/util/cookieSetting";
 import { usePathname } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 interface EmployerNoticeForm {
   hourlyPay?: number;
@@ -22,6 +23,8 @@ const EmployerNoticeForm = ({
   workHour,
   noticeDescription,
 }: EmployerNoticeForm) => {
+  const router = useRouter();
+
   const hourlyPayRef = useRef<HTMLInputElement>(null);
   const startDateRef = useRef<HTMLInputElement>(null);
   const workHourRef = useRef<HTMLInputElement>(null);
@@ -82,7 +85,9 @@ const EmployerNoticeForm = ({
           workhour: Number(workHour),
           description: noticeDescription,
         });
-        if (res.includes("Error:")) throw new Error();
+        if (typeof res === "string") throw new Error();
+
+        router.push(`../employer/notice/${res.item.id}`);
       } catch {
         alert(
           "최저 시급보다 낮은 시급을 지급하거나, 과거 시간을 선택할 수는 없습니다!",
@@ -96,7 +101,9 @@ const EmployerNoticeForm = ({
           workhour: Number(workHour),
           description: noticeDescription,
         });
-        if (res.includes("Error:")) throw new Error();
+        if (typeof res === "string") throw new Error();
+
+        router.push(`../employer/notice/${res.item.id}`);
       } catch {
         alert(
           "최저 시급보다 낮은 시급을 지급하거나, 과거 시간을 선택할 수는 없습니다!",

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { RefObject, useRef } from "react";
 import Input from "../common/Input";
 import Button from "../common/Button";
 
@@ -8,6 +8,12 @@ interface EmployerNoticeForm {
   startDate?: Date;
   workHour?: number;
   noticeDescription?: string;
+  onClick: (
+    payRef: RefObject<HTMLInputElement>,
+    dateRef: RefObject<HTMLInputElement>,
+    hourRef: RefObject<HTMLInputElement>,
+    descRef: RefObject<HTMLTextAreaElement>,
+  ) => void;
 }
 
 const EmployerNoticeForm = ({
@@ -15,19 +21,28 @@ const EmployerNoticeForm = ({
   startDate,
   workHour,
   noticeDescription,
+  onClick,
 }: EmployerNoticeForm) => {
+  const hourlyPayRef = useRef<HTMLInputElement>(null);
+  const startDateRef = useRef<HTMLInputElement>(null);
+  const workHourRef = useRef<HTMLInputElement>(null);
+  const noticeDescriptionRef = useRef<HTMLTextAreaElement>(null);
+
   return (
     <section className="grid grid-cols-3 gap-x-5">
       <Input
         inputType="WAGE"
+        inputRef={hourlyPayRef}
         defaultValue={hourlyPay ? String(hourlyPay) : ""}
       />
       <Input
         inputType="DATE"
+        inputRef={startDateRef}
         defaultValue={startDate ? String(startDate) : ""}
       />
       <Input
         inputType="WORK_HOUR"
+        inputRef={workHourRef}
         defaultValue={workHour ? String(workHour) : ""}
       />
       <label htmlFor="noticeDescription" className="mb-2 mt-6">
@@ -36,10 +51,22 @@ const EmployerNoticeForm = ({
       <textarea
         id="noticeDescription"
         className="col-start-1 col-end-4 min-h-[10rem] resize-none overflow-y-auto rounded-md border-[1px] border-gray-30 bg-white px-5 py-4"
+        ref={noticeDescriptionRef}
         defaultValue={noticeDescription}
       />
       <div className="col-start-2 mt-8">
-        <Button size="full" color="red" onClick={() => {}}>
+        <Button
+          size="full"
+          color="red"
+          onClick={() =>
+            onClick(
+              hourlyPayRef,
+              startDateRef,
+              workHourRef,
+              noticeDescriptionRef,
+            )
+          }
+        >
           {noticeDescription ? "수정하기" : "등록하기"}
         </Button>
       </div>

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -8,12 +8,6 @@ interface EmployerNoticeForm {
   startDate?: Date;
   workHour?: number;
   noticeDescription?: string;
-  onClick: (
-    payRef: RefObject<HTMLInputElement>,
-    dateRef: RefObject<HTMLInputElement>,
-    hourRef: RefObject<HTMLInputElement>,
-    descRef: RefObject<HTMLTextAreaElement>,
-  ) => void;
 }
 
 const EmployerNoticeForm = ({
@@ -21,12 +15,14 @@ const EmployerNoticeForm = ({
   startDate,
   workHour,
   noticeDescription,
-  onClick,
 }: EmployerNoticeForm) => {
+  const isEditPage = noticeDescription !== "";
   const hourlyPayRef = useRef<HTMLInputElement>(null);
   const startDateRef = useRef<HTMLInputElement>(null);
   const workHourRef = useRef<HTMLInputElement>(null);
   const noticeDescriptionRef = useRef<HTMLTextAreaElement>(null);
+
+  function handleButtonClick() {}
 
   return (
     <section className="grid grid-cols-3 gap-x-5">
@@ -55,19 +51,8 @@ const EmployerNoticeForm = ({
         defaultValue={noticeDescription}
       />
       <div className="col-start-2 mt-8">
-        <Button
-          size="full"
-          color="red"
-          onClick={() =>
-            onClick(
-              hourlyPayRef,
-              startDateRef,
-              workHourRef,
-              noticeDescriptionRef,
-            )
-          }
-        >
-          {noticeDescription ? "수정하기" : "등록하기"}
+        <Button size="full" color="red" onClick={() => {}}>
+          {isEditPage ? "수정하기" : "등록하기"}
         </Button>
       </div>
     </section>

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -18,15 +18,25 @@ const EmployerNoticeForm = ({
 }: EmployerNoticeForm) => {
   return (
     <section className="grid grid-cols-3 gap-x-5">
-      <Input inputType="WAGE" />
-      <Input inputType="DATE" />
-      <Input inputType="WORK_HOUR" />
+      <Input
+        inputType="WAGE"
+        defaultValue={hourlyPay ? String(hourlyPay) : ""}
+      />
+      <Input
+        inputType="DATE"
+        defaultValue={startDate ? String(startDate) : ""}
+      />
+      <Input
+        inputType="WORK_HOUR"
+        defaultValue={workHour ? String(workHour) : ""}
+      />
       <label htmlFor="noticeDescription" className="mb-2 mt-6">
         공고 설명
       </label>
       <textarea
         id="noticeDescription"
         className="col-start-1 col-end-4 min-h-[10rem] resize-none overflow-y-auto rounded-md border-[1px] border-gray-30 bg-white px-5 py-4"
+        defaultValue={noticeDescription}
       />
       <div className="col-start-2 mt-8">
         <Button size="full" color="red" onClick={() => {}}>

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -2,6 +2,12 @@
 import React, { RefObject, useRef, useState } from "react";
 import Input from "../common/Input";
 import Button from "../common/Button";
+import {
+  addNoticeApiResponse,
+  editSelectedNoticeApiResponse,
+} from "@/util/api";
+import { getCookie } from "@/util/cookieSetting";
+import { usePathname } from "next/navigation";
 
 interface EmployerNoticeForm {
   hourlyPay?: number;
@@ -16,17 +22,88 @@ const EmployerNoticeForm = ({
   workHour,
   noticeDescription,
 }: EmployerNoticeForm) => {
-  const isEditPage = noticeDescription !== "";
   const hourlyPayRef = useRef<HTMLInputElement>(null);
   const startDateRef = useRef<HTMLInputElement>(null);
   const workHourRef = useRef<HTMLInputElement>(null);
   const noticeDescriptionRef = useRef<HTMLTextAreaElement>(null);
 
+  const currentUrl = usePathname();
+  const isEditPage = currentUrl.includes("notice/");
+  const noticeId = isEditPage
+    ? currentUrl.split("notice/")[1].split("/edit")[0]
+    : null;
+
   const [payError, setPayError] = useState("");
   const [dateError, setDateError] = useState("");
   const [hourError, setHourError] = useState("");
 
-  function handleButtonClick() {}
+  const handleInputBlur = (
+    ref: RefObject<HTMLInputElement>,
+    setErr: (errType: string) => void,
+  ) => {
+    setErr("");
+    if (ref.current!.value === "") {
+      setErr("BLANK_REQUIRE_VALUE");
+    }
+  };
+
+  async function handleButtonClick() {
+    const hourlyPay = hourlyPayRef.current!.value;
+    const startDate = startDateRef.current!.value;
+    const workHour = workHourRef.current!.value;
+    const noticeDescription = noticeDescriptionRef.current!.value;
+    let isError = false;
+    const noticeData = [hourlyPay, startDate, workHour];
+
+    noticeData.map((item, i) => {
+      if (item === "") {
+        isError = true;
+      }
+      return;
+    });
+
+    if (isError) {
+      handleInputBlur(hourlyPayRef, setPayError);
+      handleInputBlur(startDateRef, setDateError);
+      handleInputBlur(workHourRef, setHourError);
+      return;
+    }
+    const shopId = getCookie("sid")!;
+    const localDate = new Date(startDate);
+
+    // 시차를 고려하여 RFC 3339 형식으로 변환
+    const rfc3339DateTime = localDate.toISOString().replace("0Z", "Z");
+
+    if (isEditPage) {
+      try {
+        const res = await editSelectedNoticeApiResponse(shopId, noticeId!, {
+          hourlyPay: Number(hourlyPay),
+          startsAt: String(rfc3339DateTime),
+          workhour: Number(workHour),
+          description: noticeDescription,
+        });
+        if (res.includes("Error:")) throw new Error();
+      } catch {
+        alert(
+          "최저 시급보다 낮은 시급을 지급하거나, 과거 시간을 선택할 수는 없습니다!",
+        );
+      }
+    } else {
+      try {
+        const res = await addNoticeApiResponse(shopId, {
+          hourlyPay: Number(hourlyPay),
+          startsAt: String(rfc3339DateTime),
+          workhour: Number(workHour),
+          description: noticeDescription,
+        });
+        if (res.includes("Error:")) throw new Error();
+      } catch {
+        alert(
+          "최저 시급보다 낮은 시급을 지급하거나, 과거 시간을 선택할 수는 없습니다!",
+        );
+      }
+    }
+  }
 
   return (
     <section className="grid grid-cols-3 gap-x-5">
@@ -35,18 +112,21 @@ const EmployerNoticeForm = ({
         inputRef={hourlyPayRef}
         defaultValue={hourlyPay ? String(hourlyPay) : ""}
         errorType={payError}
+        blurEvent={() => handleInputBlur(hourlyPayRef, setPayError)}
       />
       <Input
         inputType="DATE"
         inputRef={startDateRef}
         defaultValue={startDate ? String(startDate) : ""}
         errorType={dateError}
+        blurEvent={() => handleInputBlur(startDateRef, setDateError)}
       />
       <Input
         inputType="WORK_HOUR"
         inputRef={workHourRef}
         defaultValue={workHour ? String(workHour) : ""}
         errorType={hourError}
+        blurEvent={() => handleInputBlur(hourlyPayRef, setHourError)}
       />
       <label htmlFor="noticeDescription" className="mb-2 mt-6">
         공고 설명

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -1,0 +1,40 @@
+"use client";
+import React from "react";
+import Input from "../common/Input";
+import Button from "../common/Button";
+
+interface EmployerNoticeForm {
+  hourlyPay?: number;
+  startDate?: Date;
+  workHour?: number;
+  noticeDescription?: string;
+}
+
+const EmployerNoticeForm = ({
+  hourlyPay,
+  startDate,
+  workHour,
+  noticeDescription,
+}: EmployerNoticeForm) => {
+  return (
+    <section className="grid grid-cols-3 gap-x-5">
+      <Input inputType="WAGE" />
+      <Input inputType="DATE" />
+      <Input inputType="WORK_HOUR" />
+      <label htmlFor="noticeDescription" className="mb-2 mt-6">
+        공고 설명
+      </label>
+      <textarea
+        id="noticeDescription"
+        className="col-start-1 col-end-4 min-h-[10rem] resize-none overflow-y-auto rounded-md border-[1px] border-gray-30 bg-white px-5 py-4"
+      />
+      <div className="col-start-2 mt-8">
+        <Button size="full" color="red" onClick={() => {}}>
+          {noticeDescription ? "수정하기" : "등록하기"}
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default EmployerNoticeForm;

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -137,38 +137,44 @@ const EmployerNoticeForm = ({}: EmployerNoticeForm) => {
   }, []);
 
   return (
-    <section className="grid grid-cols-3 gap-x-5">
-      <Input
-        inputType="WAGE"
-        inputRef={hourlyPayRef}
-        defaultValue={hourlyPay ? String(hourlyPay) : ""}
-        errorType={payError}
-        blurEvent={() => handleInputBlur(hourlyPayRef, setPayError)}
-      />
-      <Input
-        inputType="DATE"
-        inputRef={startDateRef}
-        defaultValue={startDate ? String(startDate) : ""}
-        errorType={dateError}
-        blurEvent={() => handleInputBlur(startDateRef, setDateError)}
-      />
-      <Input
-        inputType="WORK_HOUR"
-        inputRef={workHourRef}
-        defaultValue={workHour ? String(workHour) : ""}
-        errorType={hourError}
-        blurEvent={() => handleInputBlur(hourlyPayRef, setHourError)}
-      />
-      <label htmlFor="noticeDescription" className="mb-2 mt-6">
-        공고 설명
-      </label>
-      <textarea
-        id="noticeDescription"
-        className="col-start-1 col-end-4 min-h-[10rem] resize-none overflow-y-auto rounded-md border-[1px] border-gray-30 bg-white px-5 py-4"
-        ref={noticeDescriptionRef}
-        defaultValue={noticeDescription}
-      />
-      <div className="col-start-2 mt-8">
+    <section className="mobgap-y-5 grid grid-cols-3 gap-x-5 gap-y-8 tab:grid-cols-4 mob:grid-cols-1">
+      <div className="col-start-1 tab:col-end-3 mob:col-end-2">
+        <Input
+          inputType="WAGE"
+          inputRef={hourlyPayRef}
+          defaultValue={hourlyPay ? String(hourlyPay) : ""}
+          errorType={payError}
+          blurEvent={() => handleInputBlur(hourlyPayRef, setPayError)}
+        />
+      </div>
+      <div className="tab:col-start-3 tab:col-end-5 mob:col-end-2 mob:tab:col-start-1">
+        <Input
+          inputType="DATE"
+          inputRef={startDateRef}
+          defaultValue={startDate ? String(startDate) : ""}
+          errorType={dateError}
+          blurEvent={() => handleInputBlur(startDateRef, setDateError)}
+        />
+      </div>
+      <div className="tab:col-start-1 tab:col-end-3 mob:col-start-1 mob:col-end-2">
+        <Input
+          inputType="WORK_HOUR"
+          inputRef={workHourRef}
+          defaultValue={workHour ? String(workHour) : ""}
+          errorType={hourError}
+          blurEvent={() => handleInputBlur(hourlyPayRef, setHourError)}
+        />
+      </div>
+      <div className="col-start-1 col-end-4 flex flex-col tab:col-end-6 mob:col-end-2">
+        <label htmlFor="noticeDescription">공고 설명</label>
+        <textarea
+          id="noticeDescription"
+          className="min-h-[10rem] resize-none overflow-y-auto rounded-md border-[1px] border-gray-30 bg-white px-5 py-4 "
+          ref={noticeDescriptionRef}
+          defaultValue={noticeDescription}
+        />
+      </div>
+      <div className="col-start-2 col-end-3 tab:col-start-2 tab:col-end-4 mob:col-start-1 mob:col-end-2">
         <Button size="full" color="red" onClick={() => handleButtonClick()}>
           {isEditPage ? "수정하기" : "등록하기"}
         </Button>

--- a/src/components/employer/EmployerNoticeForm.tsx
+++ b/src/components/employer/EmployerNoticeForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { RefObject, useRef } from "react";
+import React, { RefObject, useRef, useState } from "react";
 import Input from "../common/Input";
 import Button from "../common/Button";
 
@@ -22,6 +22,10 @@ const EmployerNoticeForm = ({
   const workHourRef = useRef<HTMLInputElement>(null);
   const noticeDescriptionRef = useRef<HTMLTextAreaElement>(null);
 
+  const [payError, setPayError] = useState("");
+  const [dateError, setDateError] = useState("");
+  const [hourError, setHourError] = useState("");
+
   function handleButtonClick() {}
 
   return (
@@ -30,16 +34,19 @@ const EmployerNoticeForm = ({
         inputType="WAGE"
         inputRef={hourlyPayRef}
         defaultValue={hourlyPay ? String(hourlyPay) : ""}
+        errorType={payError}
       />
       <Input
         inputType="DATE"
         inputRef={startDateRef}
         defaultValue={startDate ? String(startDate) : ""}
+        errorType={dateError}
       />
       <Input
         inputType="WORK_HOUR"
         inputRef={workHourRef}
         defaultValue={workHour ? String(workHour) : ""}
+        errorType={hourError}
       />
       <label htmlFor="noticeDescription" className="mb-2 mt-6">
         공고 설명
@@ -51,7 +58,7 @@ const EmployerNoticeForm = ({
         defaultValue={noticeDescription}
       />
       <div className="col-start-2 mt-8">
-        <Button size="full" color="red" onClick={() => {}}>
+        <Button size="full" color="red" onClick={() => handleButtonClick()}>
           {isEditPage ? "수정하기" : "등록하기"}
         </Button>
       </div>

--- a/src/components/employer/FormCloseButton.tsx
+++ b/src/components/employer/FormCloseButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+const FormCloseButton = ({ redirectRoute }: { redirectRoute: string }) => {
+  const router = useRouter();
+  return (
+    <button
+      onClick={() => router.push(redirectRoute)}
+      className="relative h-8 w-8"
+    >
+      <Image fill src={"/close.svg"} alt="close-notice-register" />
+    </button>
+  );
+};
+
+export default FormCloseButton;

--- a/src/components/employer/FormCloseButton.tsx
+++ b/src/components/employer/FormCloseButton.tsx
@@ -6,9 +6,11 @@ import React from "react";
 
 const FormCloseButton = () => {
   const router = useRouter();
-  console.log(router);
   return (
-    <button onClick={() => router.back()} className="relative h-8 w-8">
+    <button
+      onClick={() => router.back()}
+      className="relative h-8 w-8 mob:h-6 mob:w-6"
+    >
       <Image fill src={"/close.svg"} alt="close-notice-register" />
     </button>
   );

--- a/src/components/employer/FormCloseButton.tsx
+++ b/src/components/employer/FormCloseButton.tsx
@@ -4,13 +4,11 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import React from "react";
 
-const FormCloseButton = ({ redirectRoute }: { redirectRoute: string }) => {
+const FormCloseButton = () => {
   const router = useRouter();
+  console.log(router);
   return (
-    <button
-      onClick={() => router.push(redirectRoute)}
-      className="relative h-8 w-8"
-    >
+    <button onClick={() => router.back()} className="relative h-8 w-8">
       <Image fill src={"/close.svg"} alt="close-notice-register" />
     </button>
   );

--- a/src/components/employer/StoreRegisterForm.tsx
+++ b/src/components/employer/StoreRegisterForm.tsx
@@ -83,6 +83,7 @@ const StoreRegisterForm = () => {
     if (sid !== undefined) {
       router.push("/employer");
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/util/constants/INPUT_VALUES.ts
+++ b/src/util/constants/INPUT_VALUES.ts
@@ -53,6 +53,7 @@ export const INPUT_PLACEHOLDER: InputValuesType = {
 export const INPUT_LAST_WORD: InputValuesType = {
   DEFAULT: "기본 어미",
   WAGE: "원",
+  WORK_HOUR: "시간",
 };
 
 export const INPUT_ERROR_TYPE: InputValuesType = {
@@ -66,7 +67,11 @@ export const INPUT_ERROR_TYPE: InputValuesType = {
   BLANK_REQUIRE_VALUE: "*은 필수 항목입니다.",
 };
 
-export const INPUT_SELECT_TYPE: string[] = ["MAIN_ADDRESS", "WORK_TYPES", "FAVOR_ADDRESS"];
+export const INPUT_SELECT_TYPE: string[] = [
+  "MAIN_ADDRESS",
+  "WORK_TYPES",
+  "FAVOR_ADDRESS",
+];
 
 export const INPUT_SELECT_DATA_LIST: { [key: string]: string[] } = {
   MAIN_ADDRESS: [

--- a/src/util/constants/INPUT_VALUES.ts
+++ b/src/util/constants/INPUT_VALUES.ts
@@ -26,7 +26,7 @@ export const INPUT_LABELS: InputValuesType = {
   DATE: "시작 일시*",
   BASE_WAGE: "기본 시급*",
   WAGE: "시급*",
-  WORK_HOUR: "업무 시간",
+  WORK_HOUR: "업무 시간*",
   WORK_TYPES: "분류*",
   STORE_NAME: "가게 이름*",
   MAIN_ADDRESS: "주소",

--- a/src/util/constants/INPUT_VALUES.ts
+++ b/src/util/constants/INPUT_VALUES.ts
@@ -7,7 +7,7 @@ export const INPUT_TYPES: InputValuesType = {
   EMAIL: "email",
   PASSWORD: "password",
   PASSWORD_CHECK: "password",
-  DATE: "date",
+  DATE: "datetime-local",
   BASE_WAGE: "number",
   WAGE: "number",
   WORK_HOUR: "number",


### PR DESCRIPTION
## 🚀 작업 내용

- 사장 페이지에서 공고 등록하기 버튼을 눌렀을 경우, 새로운 공고를 등록하는 창으로 이동이 가능해졌습니다.
- 사장 페이지에서 공고를 클릭 할 경우 공고를 수정할 수 있는 페이지로의 이동이 가능해졌습니다.

## 📝 참고 사항

- 유저의 조작은 대부분 버튼으로 이루어질 것이라 생각하여, edit페이지의 x버튼은 '뒤로가기' 로 동작하도록 하였습니다.

## 🖼️ 스크린샷

### 공고 등록 페이지입니다.
<img width="1039" alt="스크린샷 2024-04-25 오후 6 34 44" src="https://github.com/royxk/codeit_team5_project/assets/155033024/396a1428-98f7-4e70-957b-d8069c22763e">

### 수정 전 공고 페이지입니다.
<img width="1109" alt="스크린샷 2024-04-25 오후 6 34 51" src="https://github.com/royxk/codeit_team5_project/assets/155033024/41001497-b58b-4d90-bc90-8d766d3218ee">

### 공고 상세가 들어갈 페이지 입니다. 여기에서 공고 편집 접근을 가능하게 할 예정입니다.
<img width="697" alt="스크린샷 2024-04-25 오후 6 34 57" src="https://github.com/royxk/codeit_team5_project/assets/155033024/71b893ad-390f-47d6-8f1e-401e0cfdbef8">

### 공고 수정 페이지입니다.
<img width="1095" alt="스크린샷 2024-04-25 오후 6 35 05" src="https://github.com/royxk/codeit_team5_project/assets/155033024/5bf96ce2-6611-4006-85d9-a9590fdbf512">

### 공고 수정이 정상적으로 적용된 모습입니다.
<img width="423" alt="스크린샷 2024-04-25 오후 6 35 40" src="https://github.com/royxk/codeit_team5_project/assets/155033024/de17eca7-bc6b-4973-9664-249d6b5eef45">


## 🚨 관련 이슈

- 오늘 데일리 스크럼에 논의 되었던 내용은 아직 전체 페이지 기능 구현이 끝나지 않아 손을 보지 않았습니다.
