### PR TITLE
[PTTF-79] Pagination 버그 픽스

### DIFF
--- a/src/app/paginationTest/page.tsx
+++ b/src/app/paginationTest/page.tsx
@@ -5,7 +5,7 @@ import React, { useRef, useState } from "react";
 type Props = {};
 
 const PaginationTest = (props: Props) => {
-  const [pageNum, setPageNum] = useState(0);
+  const [pageNum, setPageNum] = useState(50);
 
   const inputNum = useRef<HTMLInputElement>(null);
   return (

--- a/src/app/paginationTest/page.tsx
+++ b/src/app/paginationTest/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+import Pagination from "@/components/common/Pagination";
+import React, { useRef, useState } from "react";
+
+type Props = {};
+
+const PaginationTest = (props: Props) => {
+  const [pageNum, setPageNum] = useState(0);
+
+  const inputNum = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <input
+        className="min-w-20 border-2 border-black bg-gray-5 px-5 py-5"
+        ref={inputNum}
+      ></input>
+
+      <Pagination count={pageNum} setCurrentPageData={() => {}} />
+      <button onClick={() => setPageNum(Number(inputNum.current!.value))}>
+        {" "}
+        바꾸기 버튼
+      </button>
+    </>
+  );
+};
+
+export default PaginationTest;

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -33,19 +33,8 @@ const Pagination = ({
   const pageData = Math.ceil(count / pageItemLimit);
   const [currentPage, setCurrentPage] = useState(0);
   const [currentPageList, setCurrentPageList] = useState([0]);
-  console.log(pageData);
-  const isPaginationNeed = pageData > 7;
 
-  const firstPageList: number[] = [];
-  if (!isPaginationNeed) {
-    if (pageData === 0) {
-      firstPageList.push(0);
-    } else {
-      for (let i = 0; i < pageData; i++) {
-        firstPageList.push(i);
-      }
-    }
-  }
+  const isPaginationNeed = pageData > 7;
 
   // 현재 선택 가능한 페이지 리스트를 다루는 함수, pagination이 필요하지 않으면 작동하지 않음
   const handlePageList = (targetPageNumber: number) => {
@@ -105,12 +94,24 @@ const Pagination = ({
   };
 
   useEffect(() => {
+    const firstPageList: number[] = [];
+    if (!isPaginationNeed) {
+      if (pageData === 0) {
+        firstPageList.push(0);
+      } else {
+        for (let i = 0; i < pageData; i++) {
+          firstPageList.push(i);
+        }
+      }
+    }
     setCurrentPageList(firstPageList);
     handlePageNumberChange(0);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [count]);
 
   useEffect(() => {
     handlePageNumberChange(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageRefreshSwitch]);
 
   return (

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -152,12 +152,11 @@ const Pagination = ({
 
       <div className="flex gap-1">
         {currentPageList.map((item) => (
-          <>
+          <div key={`pagination-${item + 1}`}>
             {enableAnchorNavigation ? (
               <Link href={`#filterdNoticeSection`}>
                 <button
                   type="button"
-                  key={`pagination-${item + 1}`}
                   className={`h-10 w-10 rounded-[4px] mob:h-8 mob:w-8 mob:text-xs 
             ${currentPage === item ? "bg-red-30 text-white" : "text-black hover:bg-gray-10"}`}
                   onClick={() => handlePageNumberChange(item)}
@@ -168,7 +167,6 @@ const Pagination = ({
             ) : (
               <button
                 type="button"
-                key={`pagination-${item + 1}`}
                 className={`h-10 w-10 rounded-[4px] mob:h-8 mob:w-8 mob:text-xs
             ${currentPage === item ? "bg-red-30 text-white" : "text-black hover:bg-gray-10"}`}
                 onClick={() => handlePageNumberChange(item)}
@@ -176,7 +174,7 @@ const Pagination = ({
                 {item + 1}
               </button>
             )}
-          </>
+          </div>
         ))}
       </div>
       {enableAnchorNavigation ? (


### PR DESCRIPTION
## 🚀 작업 내용

- count의 변동에 따라 페이지 리스트에 그 변동이 적용될 수 있도록 하였습니다.

## 📝 참고 사항

- 일단 대략적으로 시험은 해봤는데, 이게 수환님이 의도하신 사항에 맞으실지는 잘 모르겠네요.
- 삼항 연산자 때문인지 key 에러가 나서 상위 fragment를 div로 만들고 key값을 넣었습니다.


## 🖼️ 스크린샷

### count 변경 전 입니다.(count - 40)
<img width="919" alt="스크린샷 2024-04-26 오전 10 11 00" src="https://github.com/royxk/codeit_team5_project/assets/155033024/acdec76e-03b3-46f9-9815-ec3ca50fe1cf">

### count 변경 후입니다.(count - 0)
<img width="817" alt="스크린샷 2024-04-26 오전 10 11 09" src="https://github.com/royxk/codeit_team5_project/assets/155033024/16e36883-591c-4975-9541-ba7f25a21db8">

### count 시작값이 0일때입니다.
<img width="837" alt="스크린샷 2024-04-26 오전 10 11 43" src="https://github.com/royxk/codeit_team5_project/assets/155033024/e56f009a-6618-41af-8830-9d7c2ee8a498">

### 혹시 테스트 페이지가 필요하실까봐 스타일을 조금 더 시인성 좋게 다듬었습니다.
<img width="825" alt="스크린샷 2024-04-26 오전 10 15 36" src="https://github.com/royxk/codeit_team5_project/assets/155033024/0c66a2e0-725f-4535-9538-3f77a5484fdc">

## 🚨 관련 이슈

- #69 
