### PR TITLE
[PTTF-81] 유저 타입에 따른 버튼 차별화 및 공고 신청 및 취소 기능

### DIFF
--- a/src/components/common/StoreDetail/index.tsx
+++ b/src/components/common/StoreDetail/index.tsx
@@ -16,7 +16,7 @@ import { formatApiDateData } from "@/util/formatDate";
  */
 const StoreDetail = ({ data }: { data?: StoreDetailProps }) => {
   const item = data?.item;
-  console.log(item);
+
   // 가게 데이터가 유효하지 않을 경우. 현재 유저에 대한 구분이 없으므로, 잘못된 공고 링크로의 접근의 경우 추가 리다이렉트가 필요합니다.
   if (item === undefined)
     return (


### PR DESCRIPTION
## 🚀 작업 내용

- 현재 로그인된 유저의 타입에 따라 버튼을 다르게 표시하고, 공고 신청 및 취소를 가능하게 했습니다.

## 📝 참고 사항

-

## 🖼️ 스크린샷

<img width="1025" alt="스크린샷 2024-04-26 오후 2 39 55" src="https://github.com/royxk/codeit_team5_project/assets/155033024/e346407a-2869-417c-9adc-de372f237b24">


## 🚨 관련 이슈

-
