### PR TITLE
[PTTF-99] ✨ 상세필터 숫자만 9자까지 입력받게 수정

### DIFF
--- a/src/components/common/AdvancedFilter/AdvancedFilter.tsx
+++ b/src/components/common/AdvancedFilter/AdvancedFilter.tsx
@@ -72,6 +72,20 @@ function AdvancedFilter({
     setIsAdvancedFilterOpen(false);
   };
 
+  //숫자로 구성된 문자열로 변환하고 9자를 넘기지 않도록 변경
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    const numericValue = newValue.replace(/\D/g, "");
+    setPrice(numericValue.substring(0, 9));
+  };
+
+  //백스페이스와 숫자만 허용
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Backspace" && !/\d/.test(e.key)) {
+      e.preventDefault();
+    }
+  };
+
   // Effect to handle inputs and locations changes
   useEffect(() => {
     updateCount();
@@ -116,9 +130,11 @@ function AdvancedFilter({
               <input
                 className={`focus:outline-none`}
                 placeholder="입력"
-                type="number"
+                type="text"
                 value={price}
-                onChange={(e) => setPrice(e.target.value)}
+                maxLength={9}
+                onKeyDown={(e) => handleInputKeyDown(e)}
+                onChange={(e) => handleInputChange(e)}
               />
               <div>원</div>
             </div>


### PR DESCRIPTION
## 🚀 작업 내용

- 상세필터의 금액 입력란에 9자까지만 입력 가능하고 문자는 입력을 막도록 변경

## 📝 참고 사항

- 잘 작동됩니다.

## 🖼️ 스크린샷

![image](https://github.com/royxk/codeit_team5_project/assets/155133655/2dce8f27-7d6e-47e9-883f-eca8fa6712e2)

## 🚨 관련 이슈

- 없습니다
