### PR TITLE
[PTTF-103] Table 컴포넌트 소개란 호버 시 전체 소개 글이 뜨도록 수정

### DIFF
--- a/src/components/common/SignModal.tsx
+++ b/src/components/common/SignModal.tsx
@@ -23,7 +23,7 @@ const Modal: React.FC<ModalProps> = ({
       onClick={onClose}
     >
       <div
-        className={`${className}m-6 mb-4 flex h-[240px] w-[480px] flex-col items-center justify-center rounded-lg bg-white pb-4`}
+        className={`${className} m-6 mb-4 flex h-[240px] w-[480px] flex-col items-center justify-center rounded-lg bg-white pb-4`}
         onClick={handleNotCloseModalClick}
       >
         <div className="relative">

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -1,12 +1,10 @@
 "use client";
-import { MouseEvent, useState } from "react";
+import { useState } from "react";
 import ApproveButtons from "./ApproveButtons";
 import Pagination from "./Pagination";
 import StatusLabel from "./StatusLabel";
 import TableHeader from "./TableHeader";
 import { formatApiDateData } from "@/util/formatDate";
-import ModalPortal from "./ModalPortal";
-import Modal from "./SignModal";
 
 interface TableProps<T> {
   headerData: string[];
@@ -35,9 +33,7 @@ const Table = <T extends ApplyData>({
   applyData,
 }: TableProps<T>) => {
   const isEmployee = headerData.includes("가게");
-  const [showModal, setShowModal] = useState(false);
   const [pageData, setPageData] = useState([]);
-  const [bioValue, setBioValue] = useState('');
   const currentPageData: any[] = [];
 
   for (let i = 0; i < applyData.length; i += 5) {
@@ -47,15 +43,6 @@ const Table = <T extends ApplyData>({
   const handleData = (pageData: number) => {
     setPageData(currentPageData[pageData]);
   };
-  
-  const handleClick = (bio: string) => {
-    setBioValue(bio)
-    setShowModal(true);
-  }
-
-  const handleOutsideClick = (e: MouseEvent<HTMLDivElement>) => {
-    setShowModal(false);
-  }
 
   return (
     <div className="relative w-full max-w-[964px] overflow-hidden rounded-lg border border-gray-20 mob:text-sm">
@@ -114,16 +101,6 @@ const Table = <T extends ApplyData>({
         </table>
       </div>
       <Pagination count={applyData.length} setCurrentPageData={handleData} />
-      {/* <ModalPortal>
-        {showModal && (
-          <Modal
-            onClose={handleOutsideClick}>
-            <div>
-              {bioValue}
-            </div>
-          </Modal>
-        )}
-      </ModalPortal> */}
     </div>
   );
 };

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -1,10 +1,12 @@
 "use client";
-import { useState } from "react";
+import { MouseEvent, useState } from "react";
 import ApproveButtons from "./ApproveButtons";
 import Pagination from "./Pagination";
 import StatusLabel from "./StatusLabel";
 import TableHeader from "./TableHeader";
 import { formatApiDateData } from "@/util/formatDate";
+import ModalPortal from "./ModalPortal";
+import Modal from "./SignModal";
 
 interface TableProps<T> {
   headerData: string[];
@@ -33,7 +35,9 @@ const Table = <T extends ApplyData>({
   applyData,
 }: TableProps<T>) => {
   const isEmployee = headerData.includes("가게");
+  const [showModal, setShowModal] = useState(false);
   const [pageData, setPageData] = useState([]);
+  const [bioValue, setBioValue] = useState('');
   const currentPageData: any[] = [];
 
   for (let i = 0; i < applyData.length; i += 5) {
@@ -43,6 +47,15 @@ const Table = <T extends ApplyData>({
   const handleData = (pageData: number) => {
     setPageData(currentPageData[pageData]);
   };
+  
+  const handleClick = (bio: string) => {
+    setBioValue(bio)
+    setShowModal(true);
+  }
+
+  const handleOutsideClick = (e: MouseEvent<HTMLDivElement>) => {
+    setShowModal(false);
+  }
 
   return (
     <div className="relative w-full max-w-[964px] overflow-hidden rounded-lg border border-gray-20 mob:text-sm">
@@ -63,37 +76,51 @@ const Table = <T extends ApplyData>({
                 bio,
               } = data;
               return (
-                <tr
-                  key={apply_id}
-                  className="h-[68px] border-b border-gray-20 mob:h-[50px]"
-                >
-                  <td className="sticky left-0 z-10 w-full min-w-[226px] bg-white pl-3 mob:min-w-[188px]">
-                    {isEmployee ? shopName : userName}
-                  </td>
-                  <td className="w-full min-w-[300px] bg-white pl-3 align-middle">
-                    <div className="line-clamp-1">
-                      {isEmployee
-                        ? formatApiDateData(startsAt, workHour).join(" ")
-                        : bio}
-                    </div>
-                  </td>
-                  <td className="w-full min-w-[200px] bg-white pl-3">
-                    {isEmployee ? `${hourlyPay}원` : phoneNumber}
-                  </td>
-                  <td className="w-full min-w-[236px] bg-white pl-3 mob:min-w-[168px]">
-                    {!isEmployee && status === "pending" ? (
-                      <ApproveButtons noticeApplyId={apply_id}/>
-                    ) : (
-                      <StatusLabel status={status} />
-                    )}
-                  </td>
-                </tr>
+                <>
+                  <tr
+                    key={apply_id}
+                    className="h-[68px] border-b border-gray-20 mob:h-[50px]"
+                  >
+                    <td className="sticky left-0 z-10 w-full min-w-[226px] bg-white pl-3 mob:min-w-[188px]">
+                      {isEmployee ? shopName : userName}
+                    </td>
+                    <td className="w-full min-w-[300px] bg-white pl-3 align-middle">
+                      <button onClick={() => handleClick(bio)}>
+                        <div className="line-clamp-1">
+                          {isEmployee
+                            ? formatApiDateData(startsAt, workHour).join(" ")
+                            : bio}
+                        </div>
+                      </button>
+                    </td>
+                    <td className="w-full min-w-[200px] bg-white pl-3">
+                      {isEmployee ? `${hourlyPay}원` : phoneNumber}
+                    </td>
+                    <td className="w-full min-w-[236px] bg-white pl-3 mob:min-w-[168px]">
+                      {!isEmployee && status === "pending" ? (
+                        <ApproveButtons noticeApplyId={apply_id}/>
+                      ) : (
+                        <StatusLabel status={status} />
+                      )}
+                    </td>
+                  </tr>
+                </>
               );
             })}
           </tbody>
         </table>
       </div>
       <Pagination count={applyData.length} setCurrentPageData={handleData} />
+      <ModalPortal>
+        {showModal && (
+          <Modal
+            onClose={handleOutsideClick}>
+            <div>
+              {bioValue}
+            </div>
+          </Modal>
+        )}
+      </ModalPortal>
     </div>
   );
 };

--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -85,13 +85,16 @@ const Table = <T extends ApplyData>({
                       {isEmployee ? shopName : userName}
                     </td>
                     <td className="w-full min-w-[300px] bg-white pl-3 align-middle">
-                      <button onClick={() => handleClick(bio)}>
-                        <div className="line-clamp-1">
-                          {isEmployee
-                            ? formatApiDateData(startsAt, workHour).join(" ")
-                            : bio}
-                        </div>
-                      </button>
+                      <div className="peer line-clamp-1">
+                        {isEmployee
+                          ? formatApiDateData(startsAt, workHour).join(" ")
+                          : bio}
+                      </div>
+                      {!isEmployee &&
+                        <div
+                          className={`absolute mb-2 hidden w-[400px] line-clamp-3 rounded-md bg-black px-2 py-1 text-xs text-white opacity-0 peer-hover:block peer-hover:opacity-100`}>
+                          {bio}
+                        </div>}
                     </td>
                     <td className="w-full min-w-[200px] bg-white pl-3">
                       {isEmployee ? `${hourlyPay}원` : phoneNumber}
@@ -111,7 +114,7 @@ const Table = <T extends ApplyData>({
         </table>
       </div>
       <Pagination count={applyData.length} setCurrentPageData={handleData} />
-      <ModalPortal>
+      {/* <ModalPortal>
         {showModal && (
           <Modal
             onClose={handleOutsideClick}>
@@ -120,7 +123,7 @@ const Table = <T extends ApplyData>({
             </div>
           </Modal>
         )}
-      </ModalPortal>
+      </ModalPortal> */}
     </div>
   );
 };


### PR DESCRIPTION
## 🚀 작업 내용

- 내 가게 -> 공고 상세 페이지에서 지원자의 소개글을 마우스 호버 시 아래에 전체 소개글이 뜨도록 구현했습니다.


## 📝 참고 사항

- 소개글의 제한은 300자 입니다.
- 모달 창의 className을 넣는 부분이 다른 class 코드와 붙어 css가 먹히지 않는 현상이 있었습니다. 현재 공백을 넣어 해결하였으니 걱정하지 않으셔도 됩니다.

## 🖼️ 스크린샷

- 소개글이 300자일 때
![스크린샷 2024-04-28 144701](https://github.com/royxk/codeit_team5_project/assets/155137866/2533ac2c-56f8-48ff-9532-e1fd5e2658f1)


## 🚨 관련 이슈

- 알바님으로 로그인 했을 때 아무런 content도 들어가지 않는 검은 창이 뜨기에 isEmployee 값으로 사장님 페이지일 때에만 창이 뜨도록 했습니다.
