### PR TITLE
[PTTF-116] ♻️ 툴팁 z-index 추가하여 post 사진보다 위로 올라가게 수정

### DIFF
--- a/src/components/common/Post/Tooltip.tsx
+++ b/src/components/common/Post/Tooltip.tsx
@@ -8,10 +8,11 @@ type TooltipProps = {
 
 const Tooltip = ({ children, content, isClosed }: TooltipProps) => {
   return (
-    <div className="group relative flex items-center">
+    <div className="group relative z-[60] flex items-center">
       {children}
       <div
-        className={`absolute bottom-full mb-2 hidden w-auto whitespace-nowrap rounded-md bg-black px-2 py-1 text-xs text-white opacity-0 ${isClosed ? "group-hover:block group-hover:opacity-100" : ""}`}>
+        className={`absolute bottom-full mb-2 hidden w-auto whitespace-nowrap rounded-md bg-black px-2 py-1 text-xs text-white opacity-0 ${isClosed ? "group-hover:block group-hover:opacity-100" : ""}`}
+      >
         {content}
       </div>
     </div>


### PR DESCRIPTION
## 🚀 작업 내용

- 툴팁 z-index 추가

## 📝 참고 사항

-

## 🖼️ 스크린샷

![image](https://github.com/royxk/codeit_team5_project/assets/155133655/bc240d8e-5be1-4716-adf4-a84a2b44df32)


## 🚨 관련 이슈

-
