### PR TITLE
[PTTF-115] 시연 단계에서 발견된 employer관련 버그 제거

### DIFF
--- a/src/components/common/NoticeDetail/index.tsx
+++ b/src/components/common/NoticeDetail/index.tsx
@@ -88,7 +88,7 @@ const NoticeDetail = ({ data }: { data?: StoreDetailPostType }) => {
             <div>
               <h1 className="body1-bold mob:body2-bold text-primary">시급</h1>
               <div className="mt-2 flex h-10 w-full items-center gap-2 mob:gap-1">
-                {item.hourlyPay ? (
+                {originalHourlyPay ? (
                   <>
                     <Tooltip
                       isClosed={!isClosed}
@@ -122,7 +122,7 @@ const NoticeDetail = ({ data }: { data?: StoreDetailPostType }) => {
               <div className="flex-rwo relative mr-1 h-5 w-5 ">
                 <Image src={"/post/time.svg"} alt="" fill />
               </div>
-              {item.hourlyPay ? (
+              {originalHourlyPay ? (
                 <a className="body1 mob:body2 text-gray-50">
                   {" " + workHour[0] + " " + workHour[1]}
                 </a>
@@ -135,7 +135,7 @@ const NoticeDetail = ({ data }: { data?: StoreDetailPostType }) => {
               <div className="flex-rwo relative mr-1 h-5 w-5 ">
                 <Image src={"/post/location.svg"} alt="" fill />
               </div>
-              {shopData.address1 ? (
+              {originalHourlyPay ? (
                 <p className="body1 mob:body2 text-gray-50">
                   {shopData.address1}
                 </p>
@@ -144,7 +144,7 @@ const NoticeDetail = ({ data }: { data?: StoreDetailPostType }) => {
               )}
             </div>
 
-            {shopData.description ? (
+            {originalHourlyPay ? (
               <textarea
                 disabled
                 className="body1 mob:body2 h-16 w-full resize-none overflow-y-auto bg-transparent"

--- a/src/components/employer/EmployerStoreDetail.tsx
+++ b/src/components/employer/EmployerStoreDetail.tsx
@@ -87,7 +87,7 @@ const EmployerStoreDetail = ({ data }: { data?: ShopDataType }) => {
                 <h1 className="body1-bold mob:body2-bold text-primary">가게</h1>
                 <div className="mt-2 flex items-center gap-2 mob:gap-1">
                   <Tooltip isClosed={true} content={`${cardTitle}`}>
-                    <h2 className="h1 mob:h2 truncate">{cardTitle}</h2>
+                    <h2 className="h1 mob:h2 max-w-80 truncate">{cardTitle}</h2>
                   </Tooltip>
                 </div>
               </div>

--- a/src/components/employer/StoreRegisterForm.tsx
+++ b/src/components/employer/StoreRegisterForm.tsx
@@ -29,6 +29,7 @@ const StoreRegisterForm = () => {
   const [address1, setAddress1] = useState<any>("");
   const [imagePath, setImagePath] = useState("");
   const [showModal, setShowModal] = useState(false);
+  const [imageError, setImageError] = useState(false);
 
   const [isError, setIsError] = useState(false);
   const [errorMsg, setErrorMsg] = useState(false);
@@ -66,6 +67,9 @@ const StoreRegisterForm = () => {
       handleInputBlur(storeNameRef, setStoreNameErr);
       handleInputBlur(basePayRef, setBasePayErr);
       handleInputBlur(address2Ref, setAddress2Err);
+      if (storeImage === undefined) {
+        setImageError(true);
+      }
       return;
     }
 
@@ -166,10 +170,14 @@ const StoreRegisterForm = () => {
                 reader.onload = () => {
                   setImagePath(reader.result as string);
                 };
+                setImageError(false);
               }
             }}
             className="hidden"
           />
+          <p className="caption absolute bottom-0 ml-2 text-red-400">
+            {imageError ? "이미지를 꼭 등록해주세요!" : ""}
+          </p>
         </label>
       </div>
 


### PR DESCRIPTION
## 🚀 작업 내용

- 공고 상세 페이지에서의 스켈레톤이 남아있는 문제 제거
- 가게 이름이 넘어갔을 때 overflow되던 문제 제거
- 이미지 애러 메시지 추가

## 📝 참고 사항

-

## 🖼️ 스크린샷

<img width="1077" alt="스크린샷 2024-04-29 오후 6 08 16" src="https://github.com/royxk/codeit_team5_project/assets/155033024/02190d2e-f865-472e-900c-08140c5d4ebb">
<img width="555" alt="스크린샷 2024-04-29 오후 6 09 29" src="https://github.com/royxk/codeit_team5_project/assets/155033024/98c998d2-febf-4b9d-947a-78be84997fc0">
<img width="1029" alt="스크린샷 2024-04-29 오후 6 09 49" src="https://github.com/royxk/codeit_team5_project/assets/155033024/775e10db-b1cf-4d87-a240-8be3cec8e40e">


## 🚨 관련 이슈

-
